### PR TITLE
Added 'wait_for_page' to WebAppUI

### DIFF
--- a/bok_choy/web_app_ui.py
+++ b/bok_choy/web_app_ui.py
@@ -5,6 +5,7 @@ Encapsulates tests from interacting directly with Selenium.
 import socket
 from collections import Mapping
 import splinter
+from .promise import EmptyPromise, fulfill
 
 import logging
 LOGGER = logging.getLogger(__name__)
@@ -155,6 +156,23 @@ class WebAppUI(Mapping):
 
         # Ask the page object to verify that the correct page loaded
         self._verify_page(page)
+
+    def wait_for_page(self, page_name, timeout=30):
+        """
+        Block until the page named `page_name` loads.
+
+        Useful for ensuring that we navigate successfully from the current
+        page to the next page.
+
+        Raises a `WebAppUIConfigError` if the page object doesn't exist.
+        Raises a `BrokenPromise` exception if the page fails to load within `timeout` seconds.
+        """
+        next_page = self._get_page_or_error(page_name)
+        return fulfill(
+            EmptyPromise(
+                next_page.is_browser_on_page,
+                "loaded page '{0}'".format(page_name)
+        ))
 
     def __getitem__(self, key):
         """

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -3,6 +3,7 @@ Page objects for interacting with the test site.
 """
 
 import os
+import time
 from bok_choy.page_object import PageObject
 from bok_choy.promise import EmptyPromise, fulfill_before, fulfill_after, fulfill
 from bok_choy.javascript import js_defined, requirejs, wait_for_js
@@ -190,6 +191,20 @@ class DelayPage(SitePage):
         )
 
         return fulfill(bad_promise)
+
+
+class NextPage(SitePage):
+    """
+    Page that loads another page after a delay.
+    """
+    NAME = "next_page"
+
+    def load_next(self, page_name, delay_sec):
+        """
+        Load the page named `page_name` after waiting for `delay_sec`.
+        """
+        time.sleep(delay_sec)
+        self.ui.visit(page_name)
 
 
 @js_defined('test_var1', 'test_var2')

--- a/tests/site/next_page.html
+++ b/tests/site/next_page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Next Page</title>
+</head>
+<body>
+    <p>Empty</p>
+</body>
+</html>

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -8,7 +8,7 @@ from nose.tools import assert_equal, assert_true
 from .pages import DelayPage
 
 
-class InputTest(WebAppTest):
+class DelayTest(WebAppTest):
     """
     Test waiting for elements to appear after a delay.
     """

--- a/tests/test_next_page.py
+++ b/tests/test_next_page.py
@@ -1,0 +1,30 @@
+"""
+Test wait until next page loads.
+"""
+
+from nose.tools import assert_raises
+from bok_choy.web_app_test import WebAppTest
+from bok_choy.web_app_ui import WebAppUIConfigError
+from bok_choy.promise import BrokenPromise
+from .pages import ButtonPage, NextPage
+
+
+class NextPageTest(WebAppTest):
+    """
+    Test wait for next page to load.
+    """
+
+    @property
+    def page_object_classes(self):
+        return [NextPage, ButtonPage]
+
+    def test_wait_for_next_page(self):
+        self.ui.visit('next_page')
+        self.ui['next_page'].load_next('button', 1)
+
+    def test_no_page_defined(self):
+        assert_raises(WebAppUIConfigError, self.ui.wait_for_page, 'not_a_page')
+
+    def test_next_page_does_not_load(self):
+        self.ui.visit('button')
+        assert_raises(BrokenPromise, self.ui.wait_for_page, 'next_page', timeout=0.1)


### PR DESCRIPTION
I tried having one page wait for another, but ran into a problem.  When I do this:

```
EmptyPromise(self.ui['page_name'].is_browser_on_page, "got to next page")
```

The `self.ui['page_name']` throws a `WrongPageError` because it's not on the right page :)

I've added a `wait_for_page` method to `WebAppUI` to work around this, since I think this will be a common pattern.

@jzoldak 
