### PR TITLE
Fix a ValueError when no port specified

### DIFF
--- a/bok_choy/web_app_ui.py
+++ b/bok_choy/web_app_ui.py
@@ -144,7 +144,7 @@ class WebAppUI(Mapping):
         url = page.url(**kwargs)
 
         # Validate the URL
-        if not self._validate_url(url):
+        if not self.validate_url(url):
             raise PageLoadError("Invalid URL: '{0}'".format(url))
 
         # Visit the URL
@@ -255,6 +255,26 @@ class WebAppUI(Mapping):
         )
         self._browser.driver.save_screenshot(image_name)
 
+    def validate_url(self, url):
+        """
+        Return a boolean indicating whether the URL has a protocol and hostname.
+        If a port is specified, ensure it is an integer.
+        """
+        result = urlparse.urlsplit(url)
+
+        # Check that we have a protocol and hostname
+        if not result.scheme or not result.netloc:
+            return False
+
+        # Check that the port is an integer
+        try:
+            if result.port is not None:
+                int(result.port)
+        except ValueError:
+            return False
+        else:
+            return True
+
     def _get_page_or_error(self, page_name):
         """
         Retrieve the page object, or raise
@@ -275,22 +295,3 @@ class WebAppUI(Mapping):
         if not page_object.is_browser_on_page():
             msg = "Not on the correct page to use '{}'".format(page_object.name)
             raise WrongPageError(msg)
-
-    def _validate_url(self, url):
-        """
-        Return a boolean indicating whether the URL has a protocol and hostname.
-        If a port is specified, ensure it is an integer.
-        """
-        result = urlparse.urlsplit(url)
-
-        # Check that we have a protocol and hostname
-        if not result.scheme or not result.netloc:
-            return False
-
-        # Check that the port is an integer
-        try:
-            int(result.port)
-        except ValueError:
-            return False
-        else:
-            return True


### PR DESCRIPTION
@jzoldak Discovered this while fixing up the E2E tests.  I refactored the test suite to use `assert_raises`, added a test case for when no port is specified, then fixed the bug in `WebAppUI.validate_url`.
