### PR TITLE
Replaced subclass properties with class variables

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -89,9 +89,7 @@ as follows:
         GitHub's search page
         """
 
-        @property
-        def name(self):
-            return 'github_search'
+        name = 'github_search'
 
         def url(self):
             return 'http://www.github.com/search'
@@ -127,9 +125,7 @@ Create a file named test_search.py in your project folder and use it to visit th
         Tests for the GitHub site.
         """
 
-        @property
-        def page_object_classes(self):
-            return [GitHubSearchPage]
+        page_object_classes = [GitHubSearchPage]
 
         def test_page_existence(self):
             """
@@ -212,9 +208,7 @@ Add a method for filling in the search term to the page object definition like t
         GitHub's search page
         """
 
-        @property
-        def name(self):
-            return 'github_search'
+        name = 'github_search'
 
         def url(self):
             return 'http://www.github.com/search'
@@ -269,9 +263,7 @@ So we add the search results page definition to pages.py:
         GitHub's search results page
         """
 
-        @property
-        def name(self):
-            return 'github_search_results'
+        name = 'github_search_results
 
         def url(self, **kwargs):
             """
@@ -308,9 +300,7 @@ Let's see how the method definition for pressing the search button would look.
         GitHub's search page
         """
 
-        @property
-        def name(self):
-            return 'github_search'
+        name = 'github_search'
 
         def url(self):
             return 'http://www.github.com/search'
@@ -346,9 +336,7 @@ Let's see how the method definition for pressing the search button would look.
         GitHub's search results page
         """
 
-        @property
-        def name(self):
-            return 'github_search_results'
+        name = 'github_search_results'
 
         def url(self, **kwargs):
             """
@@ -380,9 +368,7 @@ Now let's add the new test to test_search.py:
         Tests for the GitHub site.
         """
 
-        @property
-        def page_object_classes(self):
-            return [GitHubSearchPage]
+        page_object_classes = [GitHubSearchPage]
 
         def test_page_existence(self):
             """
@@ -450,9 +436,7 @@ results returned to the page object for the search results page.
         GitHub's search page
         """
 
-        @property
-        def name(self):
-            return 'github_search'
+        name = 'github_search'
 
         def url(self):
             return 'http://www.github.com/search'
@@ -488,9 +472,7 @@ results returned to the page object for the search results page.
         GitHub's search results page
         """
 
-        @property
-        def name(self):
-            return 'github_search_results'
+        name = 'github_search_results'
 
         def url(self, **kwargs):
             """
@@ -509,8 +491,7 @@ results returned to the page object for the search results page.
             """
             Return a list of results returned from a search
             """
-            results = self.css_text('ul.repolist > li > h3.repolist-name > a')
-            return results
+            return self.css_text('ul.repolist > li > h3.repolist-name > a')
 
 
 Improve the search test
@@ -532,9 +513,7 @@ Modify the test.py file to do these assertions:
         Tests for the GitHub site.
         """
 
-        @property
-        def page_object_classes(self):
-            return [GitHubSearchPage, GitHubSearchResultsPage]
+        page_object_classes = [GitHubSearchPage, GitHubSearchResultsPage]
 
         def test_page_existence(self):
             """

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -18,19 +18,12 @@ class SitePage(PageObject):
     # (set by the test runner script)
     SERVER_PORT = os.environ.get("SERVER_PORT", 8003)
 
-    # Subclasses override this
-    NAME = None
-
     def is_browser_on_page(self):
-        title = self.NAME.lower().replace('_', ' ')
+        title = self.name.lower().replace('_', ' ')
         return title in self.browser.title.lower()
 
     def url(self, **kwargs):
-        return "http://localhost:{0}/{1}".format(self.SERVER_PORT, self.NAME + ".html")
-
-    @property
-    def name(self):
-        return self.NAME
+        return "http://localhost:{0}/{1}".format(self.SERVER_PORT, self.name + ".html")
 
     @property
     def output(self):
@@ -51,7 +44,7 @@ class ButtonPage(SitePage):
     """
     Page for testing button interactions.
     """
-    NAME = "button"
+    name = "button"
 
     def click_button(self):
         """
@@ -65,7 +58,7 @@ class TextFieldPage(SitePage):
     """
     Page for testing text field interactions.
     """
-    NAME = "text_field"
+    name = "text_field"
 
     def enter_text(self, text):
         """
@@ -78,7 +71,7 @@ class SelectPage(SitePage):
     """
     Page for testing select input interactions.
     """
-    NAME = "select"
+    name = "select"
 
     def select_car(self, car_value):
         """
@@ -91,7 +84,7 @@ class CheckboxPage(SitePage):
     """
     Page for testing checkbox interactions.
     """
-    NAME = "checkbox"
+    name = "checkbox"
 
     def toggle_pill(self, pill_name):
         """
@@ -104,7 +97,7 @@ class AlertPage(SitePage):
     """
     Page for testing alert handling.
     """
-    NAME = "alert"
+    name = "alert"
 
     def confirm(self):
         with self.handle_alert(confirm=True):
@@ -124,7 +117,7 @@ class SelectorPage(SitePage):
     Page for testing retrieval of information by CSS selectors.
     """
 
-    NAME = "selector"
+    name = "selector"
 
     @property
     def num_divs(self):
@@ -159,7 +152,7 @@ class DelayPage(SitePage):
     """
     Page for testing elements that appear after a delay.
     """
-    NAME = "delay"
+    name = "delay"
 
     def trigger_output(self):
         """
@@ -197,7 +190,7 @@ class NextPage(SitePage):
     """
     Page that loads another page after a delay.
     """
-    NAME = "next_page"
+    name = "next_page"
 
     def load_next(self, page_name, delay_sec):
         """
@@ -213,7 +206,7 @@ class JavaScriptPage(SitePage):
     Page for testing asynchronous JavaScript.
     """
 
-    NAME = "javascript"
+    name = "javascript"
 
     @wait_for_js
     def trigger_output(self):
@@ -238,7 +231,7 @@ class RequireJSPage(SitePage):
     Page for testing asynchronous JavaScript loaded with RequireJS.
     """
 
-    NAME = "requirejs"
+    name = "requirejs"
 
     @property
     @wait_for_js

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -11,10 +11,7 @@ class AlertTest(WebAppTest):
     """
     Test handling of alerts.
     """
-
-    @property
-    def page_object_classes(self):
-        return [AlertPage]
+    page_object_classes = [AlertPage]
 
     def test_confirm(self):
         self.ui.visit('alert')

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -13,9 +13,7 @@ class DelayTest(WebAppTest):
     Test waiting for elements to appear after a delay.
     """
 
-    @property
-    def page_object_classes(self):
-        return [DelayPage]
+    page_object_classes = [DelayPage]
 
     def test_delay(self):
         """

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -12,9 +12,7 @@ class InputTest(WebAppTest):
     Test basic HTML form input interactions.
     """
 
-    @property
-    def page_object_classes(self):
-        return [ButtonPage, TextFieldPage, SelectPage, CheckboxPage]
+    page_object_classes = [ButtonPage, TextFieldPage, SelectPage, CheckboxPage]
 
     def test_button(self):
         self.ui.visit('button')

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -12,9 +12,7 @@ class JavaScriptTest(WebAppTest):
     Test JavaScript synchronization.
     """
 
-    @property
-    def page_object_classes(self):
-        return [JavaScriptPage, RequireJSPage]
+    page_object_classes = [JavaScriptPage, RequireJSPage]
 
     def test_wait_for_defined(self):
         self.ui.visit('javascript')

--- a/tests/test_next_page.py
+++ b/tests/test_next_page.py
@@ -14,9 +14,7 @@ class NextPageTest(WebAppTest):
     Test wait for next page to load.
     """
 
-    @property
-    def page_object_classes(self):
-        return [NextPage, ButtonPage]
+    page_object_classes = [NextPage, ButtonPage]
 
     def test_wait_for_next_page(self):
         self.ui.visit('next_page')

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -12,9 +12,7 @@ class SelectorTest(WebAppTest):
     Test retrieving values by CSS selector.
     """
 
-    @property
-    def page_object_classes(self):
-        return [SelectorPage]
+    page_object_classes = [SelectorPage]
 
     def test_count(self):
         self.ui.visit('selector')

--- a/tests/test_web_app_ui.py
+++ b/tests/test_web_app_ui.py
@@ -15,7 +15,7 @@ class DuplicatePage(SitePage):
     """
     Create a page with the same name as another page in the test site.
     """
-    NAME = "button"
+    name = "button"
 
 
 class UnavailableURLPage(SitePage):
@@ -23,14 +23,14 @@ class UnavailableURLPage(SitePage):
     Create a page that will return a 404, since the test site
     does not serve it.
     """
-    NAME = "unavailable"
+    name = "unavailable"
 
 
 class InvalidURLPage(SitePage):
     """
     Create a page that will return a malformed URL.
     """
-    NAME = "invalid"
+    name = "invalid"
 
     def url(self, **kwargs):
         """


### PR DESCRIPTION
I was under the mistaken impression that `abstractproperty` methods wouldn't be satisfied by class variables.  Using class vars is much less verbose.

@cpennington 
