### PR TITLE
Fix all function issue

### DIFF
--- a/bok_choy/query.py
+++ b/bok_choy/query.py
@@ -410,7 +410,11 @@ class BrowserQuery(Query):
         Returns:
             bool
         """
-        return all(self.map(lambda el: el.is_selected(), 'selected').results)
+        query_results = self.map(lambda el: el.is_selected(), 'selected').results
+        if query_results:
+            return all(query_results)
+        else:
+            return False
 
     @property
     def visible(self):
@@ -420,7 +424,11 @@ class BrowserQuery(Query):
         Returns:
             bool
         """
-        return all(self.map(lambda el: el.is_displayed(), 'visible').results)
+        query_results = self.map(lambda el: el.is_displayed(), 'visible').results
+        if query_results:
+            return all(query_results)
+        else:
+            return False
 
     def click(self):
         """

--- a/tests/site/visible.html
+++ b/tests/site/visible.html
@@ -5,6 +5,6 @@
 </head>
 <body>
     <div class="batman" style="display:none">Batman</div>
-    <div class="superman">Batman</div>
+    <div class="superman">Superman</div>
 </body>
 </html>

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -30,6 +30,7 @@ class InputTest(WebAppTest):
         self.assertEquals(select.output, 'Fiat')
         self.assertTrue(select.is_car_selected('fiat'))
         self.assertFalse(select.is_car_selected('saab'))
+        self.assertFalse(select.is_car_selected('sedan'))
 
     def test_checkbox(self):
         checkbox = CheckboxPage(self.browser)

--- a/tests/test_visible.py
+++ b/tests/test_visible.py
@@ -17,3 +17,6 @@ class VisibleTest(WebAppTest):
     def test_visible(self):
         self.assertTrue(self.page.is_visible('superman'))
         self.assertFalse(self.page.is_visible('batman'))
+
+    def test_visible_with_incorrect_css_selector(self):
+        self.assertFalse(self.page.is_visible('sandman'))


### PR DESCRIPTION
Python [all](https://docs.python.org/2/library/functions.html#all) function returns True even if iterable is empty which in out case produce incorrect results.

Below is an example to explain the issue

``` html
<!DOCTYPE html>
<html>
<head>
    <title>Visible</title>
</head>
<body>
    <div class="batman" style="display:none">Batman</div>
    <div class="superman">Superman</div>
</body>
</html>
```

``` python
self.q(css="div.sandman").visible
```

The above query will return `True` which is `incorrect` because there is no `sandman` class present in above html.

This happens because bok-choy query `visible` property is defined like below 

``` python
return all(self.map(lambda el: el.is_displayed(), 'visible').results)
```

`self.map(lambda el: el.is_displayed(), 'visible').results` returns an empty list when there is an incorrect css selector but `all([])` will gives `True` and user will get the result that element is visible but in reality its not.
