### PR TITLE
Bypass media device access prompt

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Dennis Jen <djen@edx.org>
 Muhammad Ammar <mammar@gmail.com>
 Ben Patterson <bpatterson@edx.org>
 Minh-Tue Vo <minhtuev@gmail.com>
+Renzo Lucioni <renzo@edx.org>

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -202,7 +202,20 @@ def _local_browser_class(browser_name):
             "Invalid browser name {name}.  Options are: {options}".format(
                 name=browser_name, options=", ".join(BROWSERS.keys())))
     else:
-        browser_args, browser_kwargs = [], {}
+        if browser_name == 'firefox':
+            firefox_profile = webdriver.FirefoxProfile()
+
+            # Bypasses the security prompt displayed by the browser when it attempts to
+            # access a media device (e.g., a webcam)
+            firefox_profile.set_preference('media.navigator.permission.disabled', True)
+
+            browser_args = []
+            browser_kwargs = {
+                'firefox_profile': firefox_profile,
+            }
+        else:
+            browser_args, browser_kwargs = [], {}
+
         return browser_class, browser_args, browser_kwargs
 
 


### PR DESCRIPTION
Uses a Firefox profile to bypass the security prompt displayed when the browser attempts to access a media device (e.g., a webcam). Also updates the AUTHORS file.

@wedaly, could you take a look at this when you're able?