### PR TITLE
Accounting for Credentials when Validating URLs

### DIFF
--- a/bok_choy/page_object.py
+++ b/bok_choy/page_object.py
@@ -290,8 +290,8 @@ class PageObject(object):
         try:
             if result.port is not None:
                 int(result.port)
-            elif ':' in result.netloc:
-                # invalid url if there is a ':' but no port value
+            elif result.netloc.endswith(':'):
+                # Valid URLs do not end with colons.
                 return False
         except ValueError:
             return False

--- a/tests/test_page_object.py
+++ b/tests/test_page_object.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from bok_choy.page_object import PageObject, PageLoadError, unguarded, WrongPageError
 from bok_choy.promise import BrokenPromise
-from .pages import SitePage
+from tests.pages import SitePage
 
 
 class InvalidURLPage(SitePage):
@@ -65,10 +65,11 @@ class PageObjectTest(TestCase):
         it must use the correct syntax.
         """
         for url, is_valid in [
-            ("", False), ("invalid", False), ("/invalid", False),
+            ("", False), ("invalid", False), ("/invalid", False), ("http://localhost:", False),
             ("http://localhost:/invalid", False), ("://localhost/invalid", False),
             ("http://localhost", True), ("http://localhost/test", True),
-            ("http://localhost:8080", True), ("http://localhost:8080/test", True)
+            ("http://localhost:8080", True), ("http://localhost:8080/test", True),
+            ("http://user:pass@localhost/test", True), ("http://user:pass@localhost:8080/test", True)
         ]:
             returned_val = PageObject.validate_url(url)
             self.assertEquals(returned_val, is_valid, msg="Url: {0}, Expected {1} but got {2}".format(url, is_valid, returned_val))


### PR DESCRIPTION
The previous implementation did not account for basic auth credentials.

Fixes #66 

@jzoldak @benpatterson @clytwynec 