### PR TITLE
CT edits in bokchoy docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Renzo Lucioni <renzo@edx.org>
 Jonathan Piacenti <kelketek@gmail.com>
 Christina Roberts <christina@edx.org>
 Bill Agee <billagee@gmail.com>
+Carol Tong <ctong@edx.org>

--- a/docs/accessibility.rst
+++ b/docs/accessibility.rst
@@ -1,35 +1,38 @@
-Accessibility Testing
-======================
+Performing Accessibility Audits
+==================================
 
-The bok-choy framework includes the ability to test web pages for accessibility
-using `Google Accessibility Developer Tools`_.
+The bok-choy framework includes the ability to perform accessibility audits on
+web pages using `Google Accessibility Developer Tools`_.
 
-The audit rules that are checked and optionally the scope of the audit
-within the webpage itself are defined on each Page Object's definition.
+In each page object's definition you can define the audit rules to use for
+checking that page and optionally, the scope of the audit within the webpage
+itself.
 
-The general methodology for enabling accessibility auditing is:
+The general methodology for enabling accessibility auditing consists of the
+following steps.
 
-* `Define the accessibility rules to check for a page`_
-* `(optional) Define the scope for accessibility auditing of a page`_
-* Perform the audits either:
+* `Define the Audit Rules to Check for a Page`_
+* `(Optional) Define the Scope of Accessibility Auditing for a Page`_
+* Perform the audits either actively or passively.
 
-  * Actively: `Trigger the audit actively and assert on the results returned`_
-  * Passively: `Leverage your existing tests and fail on accessibility errors`_
+  * Actively: `Trigger an Audit Actively and Assert on the Results Returned`_
+  * Passively: `Leverage Your Existing Tests and Fail on Accessibility Errors`_
 
 .. note:: Accessibility auditing is only supported with PhantomJS as the browser.
 
-Define the accessibility rules to check for a page
---------------------------------------------------
 
-A page object's list of accessibility rules to audit for that page are defined
-in the axs_audit_rules_to_run method.
+Define the Audit Rules to Check for a Page
+--------------------------------------------
+
+A page object's list of audit rules to use in the accessibility audit for a
+page are defined in the ``axs_audit_rules_to_run`` method.
 
 The JavaScript code for the available rules can be found in the `audits folder`_
 of the Google Accessibility Developer Tools repository. You can find the exact
 spelling of each rule from the "name" attribute in its definition.
 
 The default for page objects is to check all the rules. This is specified by
-returning an empty list from the page object's axs_audit_rules_to_run method.
+returning an empty list from the page object's ``axs_audit_rules_to_run`` method.
 
 .. code-block:: python
 
@@ -37,7 +40,7 @@ returning an empty list from the page object's axs_audit_rules_to_run method.
         return []
 
 To check only a single rule, or multiple rules, on a particular page,
-configure the page object's axs_audit_rules_to_run method to return a list
+configure the page object's ``axs_audit_rules_to_run`` method to return a list
 with the name(s) of the rule(s).
 
 .. code-block:: python
@@ -46,7 +49,7 @@ with the name(s) of the rule(s).
         return ['badAriaAttributeValue', 'imagesWithoutAltText']
 
 To skip rules checking for a particular page, configure the page object's
-axs_audit_rules_to_run method to return None.
+``axs_audit_rules_to_run`` method to return ``None``.
 
 .. code-block:: python
 
@@ -55,20 +58,20 @@ axs_audit_rules_to_run method to return None.
 
 
 To run all rules *except* for specific ones, configure the page object's
-axs_audit_rules_to_ignore method to return a list of the rules you want to not
-check. This will take precedence over rules in axs_audit_rules_to_run. For
-instance, if we were using the example below, then the rule 'badAriaAttributeValue'
-would be ignored even if it was also listed in the page object's
-axs_audit_rules_to_run method.
+``axs_audit_rules_to_ignore`` method to return a list of the rules you do not
+want to check. This list will take precedence over the list of rules in
+``axs_audit_rules_to_run``. For instance, in the following example, the rule
+``badAriaAttributeValue`` would be ignored even if it was also listed in the
+page object's ``axs_audit_rules_to_run`` method.
 
 .. code-block:: python
 
     def axs_audit_rules_to_ignore(self):
         return ['badAriaAttributeValue']
 
-(*Default*) Defining axs_audit_rules_to_ignore to return an empty list
-will result in the rules being run however they are defined by
-axs_audit_rules_to_run.
+(*Default*) Defining ``axs_audit_rules_to_ignore`` to return an empty list
+will result in the rules being run in the way that they are defined by
+``axs_audit_rules_to_run``.
 
 .. code-block:: python
 
@@ -76,18 +79,18 @@ axs_audit_rules_to_run.
         return []
 
 
-(optional) Define the scope for accessibility auditing of a page
+(Optional) Define the Scope of Accessibility Auditing for a Page
 ----------------------------------------------------------------
 
-You can limit the scope of the audit to a portion of the page.
+You can limit the scope of an accessibility audit to only a portion of a page.
 
 The default for page objects is the entire document.
 
-To limit the scope, configure the page object's axs_scope method to return the
-element to use as the starting point via the `Selectors API`_.
+To limit the scope, configure the page object's ``axs_scope`` method to return the
+element that you want to use as the starting point via the `Selectors API`_.
 
-For example if you want to start in the div with id 'foo' then you would use
-the following:
+For instance, to start the accessibility audit in the ``div`` with id ``foo``,
+you can follow this example.
 
 .. code-block:: python
 
@@ -95,13 +98,14 @@ the following:
         return 'document.querySelector("div#foo")'
 
 
-Trigger the audit actively and assert on the results returned
+Trigger an Audit Actively and Assert on the Results Returned
 --------------------------------------------------------------
-Do this by calling the Page Object class's do_axs_audit method and then
-asserting on the results returned.
 
-Here is an example of how you might write a testcase that actively performs
-an accessibility audit:
+To trigger an accessibility audit actively, call the page object class's
+``do_axs_audit`` method and then assert on the results returned.
+
+Here is an example of how you might write a test case that actively performs
+an accessibility audit.
 
 .. code-block:: python
 
@@ -133,14 +137,18 @@ an accessibility audit:
             self.assertEqual(0, len(result.warnings))
 
 
-Leverage your existing tests and fail on accessibility errors
+Leverage Your Existing Tests and Fail on Accessibility Errors
 -------------------------------------------------------------
-Do this by setting the VERIFY_ACCESSIBILITY environment variable to True.
-This will trigger an accessibility audit whenever a Page Object's wait_for_page
-method is called, and raise an AccessibilityError if errors are found on the page.
+
+To trigger accessibility audits passively, set the ``VERIFY_ACCESSIBILITY``
+environment variable to ``True``. Doing so triggers an accessibility audit
+whenever a page object's ``wait_for_page`` method is called. If errors are
+found on the page, an AccessibilityError is raised.
+
+.. note:: An AccessibilityError is raised only on errors, not on warnings.
 
 You might already have some bok-choy tests written for your web application.
-Here is an example of one:
+Here is an example of a bok-choy test.
 
 
 .. code-block:: python
@@ -189,23 +197,24 @@ You can reuse your existing bok-choy tests in order to navigate through
 the application while at the same time verifying that it is accessibile.
 
 Before running your bok-choy tests, set the environment variable
-VERIFY_ACCESSIBILITY to true.
+``VERIFY_ACCESSIBILITY`` to ``True``.
 
 ::
 
     export VERIFY_ACCESSIBILITY=True
 
 This will trigger an audit, using the rules (and optionally the scope) set in
-the page object definition, whenever a call to wait_for_page() is made.
+the page object definition, whenever a call to ``wait_for_page()`` is made.
 
-In the case of the test_button_click_output testcase in the above example,
-an audit will be done at the end of the visit() and click_button() method calls,
-as each of those will call out to wait_for_page().
+In the case of the ``test_button_click_output`` test case in the example above,
+an audit will be done at the end of the ``visit()`` and ``click_button()`` method calls,
+as each of those will call out to ``wait_for_page()``.
 
 If any assessibility errors are found, then the testcase will fail with an
 AccessibilityError.
 
 .. note:: An AccessibilityError is raised only on errors, not on warnings.
+
 
 .. _Google Accessibility Developer Tools: https://github.com/GoogleChrome/accessibility-developer-tools
 .. _audits folder: https://github.com/GoogleChrome/accessibility-developer-tools/tree/master/src/audits

--- a/docs/visual_diff.rst
+++ b/docs/visual_diff.rst
@@ -1,23 +1,28 @@
 Visual Diff Testing
 ===================
 
-The bok-choy framework uses `Needle`_ to provide the ability to capture portions of a rendered page
-in the browser and assert that the image captured matches that of a baseline.
+The bok-choy framework uses `Needle`_ to provide the ability to capture
+portions of a rendered page in the browser and assert that the image captured
+matches that of a baseline.
 
-The general methodology for creating a test with a screenshot assertion is:
+The general methodology for creating a test with a screenshot assertion
+consists of the following steps.
 
-* `Write your page object and testcase code to navigate the system under test`_
-* `Add the call to assertScreenshot`_
-* `Create the initial baseline screenshot`_
-* `Execute your testcases after changes to the system under test`_
-* `Advanced features`_
+* `Write Your Page Object and Test Case Code to Navigate the System Under Test`_
+* `Add The Call to assertScreenshot`_
+* `Create the Initial Baseline Screenshot`_
+* `Execute Your Test Cases After Changes to the System Under Test`_
+* `Advanced Features`_
 
-Write your page object and testcase code to navigate the system under test
---------------------------------------------------------------------------
-If you are not familiar with how to write a bok-choy page object and testcase, first check out the Tutorial.
+Write Your Page Object and Test Case Code to Navigate the System Under Test
+------------------------------------------------------------------------------
+
+If you are not familiar with how to write a bok-choy page object and test case,
+first check out the Tutorial. 
+
 Here is an example of a test that navigates to the edx.org home page.
 
-**page.py**, which contains the page object:
+**page.py**, which contains the page object.
 
 .. code-block:: python
 
@@ -29,7 +34,7 @@ Here is an example of a test that navigates to the edx.org home page.
         def is_browser_on_page(self):
             return 'edx' in self.browser.title.lower()
 
-**my_test.py**, which contains the test code:
+**my_test.py**, which contains the test code.
 
 .. code-block:: python
 
@@ -41,21 +46,30 @@ Here is an example of a test that navigates to the edx.org home page.
         def test_page_existence(self):
             EdxHomePage(self.browser).visit()
 
-Add the call to assertScreenshot
+Add the Call to assertScreenshot
 --------------------------------
-assertScreenshot() take two arguments: a CSS selector for the element to capture and a filename for the image.
-Here is the same testcase, with an assertion added that will ensure that the site logo for the edx.org home
-page has not changed.
 
-* The first argument, "img.site-logo" is the css locator for the element that we want to capture and compare.
-* The second argument, "edx_logo_header" is the filename (.png will be appended automatically) that will be used
-  for both the baseline and the actual results.
+``assertScreenshot()`` takes two arguments: a CSS selector for the element to
+capture, and a filename for the image.
 
-.. note:: For test reliability and synchronization purposes, a bok-choy best practice is to employ Promises to ensure
-   that the page has been fully rendered before you take the screenshot. At the very least, you should first assert that
-   the element you want to capture is present and visible on the screen.
+The following example uses the same **my_test.py** test case shown in the
+previous section, with an assertion added to check that the site logo for the
+edx.org home page has not changed.
 
-**my_test.py**, with the screenshot assertion:
+* The first argument, ``img.site-logo`` is the css locator for the element
+  that we want to capture and compare.
+
+* The second argument, ``edx_logo_header`` is the filename that will be used
+  for both the baseline and the actual results. The .png extension is appended
+  automatically.
+
+.. note:: For test reliability and synchronization purposes, a bok-choy best
+   practice is to employ Promises to ensure that the page has been fully
+   rendered before you take the screenshot. At the very least, you should
+   first assert that the element you want to capture is present and visible on
+   the screen.
+
+**my_test.py**, with the screenshot assertion.
 
 .. code-block:: python
     :emphasize-lines: 7-10
@@ -71,46 +85,60 @@ page has not changed.
             self.assertTrue(homepage.q(css=css_locator).first.visible)
             self.assertScreenshot(css_locator, 'edx_logo_header')
 
-Create the initial baseline screenshot
+
+Create the Initial Baseline Screenshot
 --------------------------------------
-To create an initial screenshot of the logo, run in ‘baseline saving’ mode
-by specifying the nose parameter --with-save-baseline.
+
+To create an initial screenshot of the logo, run the test case in "baseline
+saving" mode by specifying the nose parameter ``--with-save-baseline``.
 
 .. code-block:: bash
 
     $ nosetests my_test.py --with-save-baseline
 
-The folder in which the baseline and actual (output) screenshots are saved is determined via the following
-environment variables:
+The folder in which the baseline and actual (output) screenshots are saved is
+determined using the following environment variables.
 
 * NEEDLE_OUTPUT_DIR - defaults to "screenshots"
 * NEEDLE_BASELINE_DIR - defaults to "screenshots/baseline"
 
-In our example, we would execute the test once with the save baseline parameter to create
-screenshots/baseline/edx_logo_header.png. We would then open it up and check that it looks okay.
+In our example, we would execute the test once with the save baseline
+parameter to create screenshots/baseline/edx_logo_header.png. We would then
+open it up and check that it looks okay.
 
-Execute your testcases after changes to the system under test
--------------------------------------------------------------
-Now if we run our tests, it will take the same screenshot and check it against the screenshot on disk:
+
+Execute Your Test Cases After Changes to the System Under Test
+---------------------------------------------------------------
+
+Now if we run our tests, it will take the same screenshot and check it against
+the saved baseline screenshot on disk.
 
 .. code-block:: bash
 
     $ nosetests my_test.py
 
-If a regression causes them to become significantly different, then the test will fail.
+If a regression causes them to become significantly different, then the test
+will fail.
 
-Advanced features
+
+Advanced Features
 -----------------
 
-See the `Needle documentation`_ for more information on these advanced features:
+See the `Needle documentation`_ for more information on the following advanced
+features.
 
-* Setting the viewport’s size - This is particularly useful for predicting the size of the resulting screenshots
-  when taking fullscreen captures, and for testing responsive sites.
-* Difference engine - Instead of PIL (the default), you may want to use PerceptualDiff. Besides being much faster
-  than PIL, PerceptualDiff also generates a diff PNG file when a test fails, highlighting the differences between the
-  baseline image and the new screenshot.
-* File cleanup - Each time you run tests, new screenshot images are saved to disk, for comparison with the
-  baseline screenshots. You may want to set your configuration to delete these files for all successful tests.
+* Setting the viewport’s size - This feature is particularly useful for
+  predicting the size of the resulting screenshots when taking full screen
+  captures, and for testing responsive sites.
+
+* Difference engine - Instead of PIL (the default), you might want to use
+  PerceptualDiff. In addition to being much faster than PIL, PerceptualDiff
+  generates a diff PNG file when a test fails, highlighting the differences
+  between the baseline image and the new screenshot.
+
+* File cleanup - Each time you run tests, new screenshot images are saved to
+  disk, for comparison with the baseline screenshots. You might want to set
+  your configuration to delete these files for all successful tests.
 
 
 .. _Needle: https://github.com/bfirsh/needle


### PR DESCRIPTION
@jzoldak This PR makes editorial changes to accessibility.rst and visualdiff.rst.

- I tried to apply consistent terminology in accessibility.rst. (accessibility audit vs testing, audit rules vs accessibility rules).
- In visualdiff.rst I made "testcase" 2 words: "test case". If this is not standard per your usage, please revert.

- In both files, I applied some of our standard style guidelines, as follows.
  - use title case (not sentence case) for titles.
  - reword for active voice where possible.
  - introduce lists using a complete sentence that ends with a period.

I also did some formatting that unfortunately made this PR's changes look more extensive than they really are. 
- Monotype formatting applied to method/field/variable names. 
- Lines wrapped at 80 chars.

