### PR TITLE
Add invisible property.

### DIFF
--- a/bok_choy/page_object.py
+++ b/bok_choy/page_object.py
@@ -521,7 +521,7 @@ class PageObject(object):
             timeout (float): Maximum number of seconds to wait for the Promise to be satisfied before timing out
 
         """
-        self.wait_for(lambda: not self.q(css=element_selector).visible, description=description, timeout=timeout)
+        self.wait_for(lambda: self.q(css=element_selector).invisible, description=description, timeout=timeout)
 
     def axs_audit_rules_to_run(self):
         """

--- a/bok_choy/query.py
+++ b/bok_choy/query.py
@@ -435,6 +435,16 @@ class BrowserQuery(Query):
         else:
             return False
 
+    @property
+    def invisible(self):
+        """
+        Check whether all matched elements are present, but not visible.
+
+        Returns:
+            bool
+        """
+        return self.present and not self.visible
+
     def click(self):
         """
         Click each matched element.

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -229,6 +229,12 @@ class VisiblePage(SitePage):
         """
         return self.q(css="div.{}".format(name)).first.visible
 
+    def is_invisible(self, name):
+        """
+        Return a boolean indicating whether the given element is present, but not visible.
+        """
+        return self.q(css="div.{}".format(name)).first.invisible
+
 
 @js_defined('test_var1', 'test_var2')
 class JavaScriptPage(SitePage):

--- a/tests/site/visible.html
+++ b/tests/site/visible.html
@@ -6,5 +6,6 @@
 <body>
     <div class="batman" style="display:none">Batman</div>
     <div class="superman">Superman</div>
+    <div class="joker" style="visibility:hidden">Joker</div>
 </body>
 </html>

--- a/tests/test_visible.py
+++ b/tests/test_visible.py
@@ -17,6 +17,16 @@ class VisibleTest(WebAppTest):
     def test_visible(self):
         self.assertTrue(self.page.is_visible('superman'))
         self.assertFalse(self.page.is_visible('batman'))
+        self.assertFalse(self.page.is_invisible('superman'))
 
     def test_visible_with_incorrect_css_selector(self):
         self.assertFalse(self.page.is_visible('sandman'))
+
+    def test_invisible(self):
+        self.assertTrue(self.page.is_invisible('joker'))
+
+    def test_not_invisible(self):
+        """
+        If an element is not present, then it cannot be invisible, either
+        """
+        self.assertFalse(self.page.is_invisible('foobar'))


### PR DESCRIPTION
Currently stating `not self.q(css=foo).visible` will return true when
an element doesn't even exist on the page. We need a truer 'invisible'
property that tests that, indeed, the element is there, but we can't see it.