### PR TITLE
refactor A11yAuditConfig.set_rules

### DIFF
--- a/bok_choy/a11y/a11y_audit.py
+++ b/bok_choy/a11y/a11y_audit.py
@@ -42,9 +42,9 @@ class A11yAuditConfig(object):
             self.rules_file = os.path.abspath(path)
 
     @abstractmethod
-    def set_rules(self, rules, ignore=False, include_type="rule"):
+    def set_rules(self, rules):
         """
-        Overrides the default list of rules to be run.
+        Overrides the default rules to be run.
 
         Raises:
 

--- a/bok_choy/a11y/axe_core_ruleset.py
+++ b/bok_choy/a11y/axe_core_ruleset.py
@@ -27,48 +27,51 @@ class AxeCoreAuditConfig(A11yAuditConfig):
             os.path.split(CUR_DIR)[0],
             'vendor/axe-core/axe.min.js'
         )
-        self.set_rules(None)
+        self.set_rules({})
         self.set_scope()
 
-    def set_rules(self, rules, ignore=False, include_type="rule"):
+    def set_rules(self, rules):
         """
-        List of rules to ignore XOR limit to when checking for accessibility
+        Set rules to ignore XOR limit to when checking for accessibility
         errors on the page.
 
         Args:
 
-            rules (list): a list of rule identifiers. If `None` or an
-                empty list, then all rules will be run.
-            ignore (bool) (optional): If you want to run all of the rules
-                except for the ones in `rules`, set this to `True`.  By
-                default this is `False`, which means _only_ the rules in
-                `rules` will be run.
-            include_type (optional): one of `"rule"` (default) or `"tag"`. If
-                set to `"tag"`, then `rules` should be a list of acessibility
-                standard tag names. Note that you _can't_ ignore tags, only
-                rules. (See below docs for more details.)
+            rules: a dictionary one of the following formats.
+                If you want to run all of the rules except for some::
+
+                    {"ignore": []}
+
+                If you want to run only a specific set of rules::
+
+                    {"apply": []}
+
+                If you want to run only rules of a specific standard::
+
+                    {"tags": []}
 
         Examples:
 
             To run only "bad-link" and "color-contrast" rules::
 
-                page.a11y_audit.config.set_rules(
-                    ["bad-link", "color-contrast"]
-                )
+                page.a11y_audit.config.set_rules({
+                    "apply": ["bad-link", "color-contrast"],
+                })
 
             To run all rules except for "bad-link" and "color-contrast"::
 
-                page.a11y_audit.config.set_rules(
-                    ["bad-link", "color-contrast"],
-                    ignore=True
-                )
+                page.a11y_audit.config.set_rules({
+                    "ignore": ["bad-link", "color-contrast"],
+                })
 
             To run only WCAG 2.0 Level A rules::
 
-                page.a11y_audit.config.set_rules(
-                    ["wcag2a"],
-                    include_type="tag"
-                )
+                page.a11y_audit.config.set_rules({
+                    "tags": ["wcag2a"],
+                })
+
+            To run all rules:
+                page.a11y_audit.config.set_rules({})
 
         Related documentation:
 
@@ -77,16 +80,20 @@ class AxeCoreAuditConfig(A11yAuditConfig):
         """
         options = {}
         if rules:
-            if ignore:
+            if rules.get("ignore"):
                 options["rules"] = {}
-                for rule in rules:
+                for rule in rules.get("ignore"):
                     options["rules"][rule] = {"enabled": False}
-            else:
+            elif rules.get("apply"):
                 options["runOnly"] = {
-                    "type": include_type,
-                    "values": rules,
+                    "type": "rule",
+                    "values": rules.get("apply"),
                 }
-
+            elif rules.get("tags"):
+                options["runOnly"] = {
+                    "type": "tag",
+                    "values": rules.get("tags"),
+                }
         self.rules = json.dumps(options)
 
     def set_scope(self, include=None, exclude=None):

--- a/bok_choy/a11y/axs_ruleset.py
+++ b/bok_choy/a11y/axs_ruleset.py
@@ -30,53 +30,43 @@ class AxsAuditConfig(A11yAuditConfig):
             os.path.split(CUR_DIR)[0],
             'vendor/google/axs_testing.js'
         )
-        self.set_rules([], ignore=False)
-        self.set_rules([], ignore=True)
+        self.set_rules({})
         self.set_scope()
 
-    def set_rules(self, rules, ignore=False, include_type="rule"):
+    def set_rules(self, rules):
         """
-        Sets `rules_to_run` or `rules_to_ignore` to the passed list of rule IDs.
+        Sets the rules to be run or ignored for the audit.
 
         Args:
 
-            rules: List of rules to ignore or run for accessibility errors on
-                the page.
-                See https://github.com/GoogleChrome/accessibility-developer-tools/tree/master/src/audits
-            ignore (bool) (optional): If you want to ignore the specified rules
-                set this to `True`.  By default this is `False`.
+            rules: a dictionary of the format `{"ignore": [], "apply": []}`.
 
-        If `ignore=False`,
+        See https://github.com/GoogleChrome/accessibility-developer-tools/tree/master/src/audits
 
-            * passing `rules=[]` means to check for all available rules.
-            * passing `rules=None` means that no audit should be done for this
-            page.
+        Passing `{"apply": []}` or `{}` means to check for all available rules.
 
-        If `ignore=True`,
+        Passing `{"apply": None}` means that no audit should be done for this page.
 
-            * passing `rules=[]` means to run all otherwise enabled rules.
-            * any specified rules will be ignored even if they were also
-            specified as rules to run.
+        Passing `{"ignore": []}` means to run all otherwise enabled rules.
+        Any rules in the "ignore" list will be ignored even if they were also
+        specified in the "apply".
 
         Examples:
 
             To check only `badAriaAttributeValue`::
 
-                page.a11y_audit.config.set_rules(
-                    ['badAriaAttributeValue']
-                )
+                page.a11y_audit.config.set_rules({
+                    "apply": ['badAriaAttributeValue']
+                })
 
             To check all rules except `badAriaAttributeValue`::
 
                 page.a11y_audit.config.set_rules(
-                    ['badAriaAttributeValue'],
-                    ignore=True
+                    "ignore": ['badAriaAttributeValue'],
                 )
         """
-        if ignore:
-            self.rules_to_ignore = rules
-        else:
-            self.rules_to_run = rules
+        self.rules_to_ignore = rules.get("ignore", [])
+        self.rules_to_run = rules.get("apply", [])
 
     def set_scope(self, include=None, exclude=None):
         """

--- a/docs/accessibility.rst
+++ b/docs/accessibility.rst
@@ -30,35 +30,33 @@ This can be updated after instantiating the page object to be tested via the
 ``set_rules`` method.
 
 The default is to check all the rules. To set this explicitly, pass an empty
-list to ``set_rules``.
+dictionary to ``set_rules``.
 
 .. code-block:: python
 
-    page.a11y_audit.config.set_rules([])
+    page.a11y_audit.config.set_rules({})
 
 To skip automatic accessibility checking for a particular page, update the
 page object's ``page.verify_accessibility`` attribute to return ``False``.
 
 To check only a specific set of rules on a particular page, pass the list of
 the names of the rules to that page's ``A11yAudit`` object's ``set_rules``
-method.
+method as the `apply` key.
 
 .. code-block:: python
 
-    page.a11y_audit.config.set_rules(
-        ['badAriaAttributeValue', 'imagesWithoutAltText']
-    )
+    page.a11y_audit.config.set_rules({
+        "apply": ['badAriaAttributeValue', 'imagesWithoutAltText'],
+    })
 
 To skip checking a specific set of rules on a particular page, pass the list
-of the names of the rules as the first argument and ``ignore=True`` as the
-second argument to that page's ``A11yAudit`` object's ``set_rules`` method.
+of the names of the rules as the first argument to that page's ``A11yAudit`` object's ``set_rules`` method as the `ignore` key.
 
 .. code-block:: python
 
-    page.a11y_audit.config.set_rules(
-        ['badAriaAttributeValue', 'imagesWithoutAltText'],
-        ignore=True
-    )
+    page.a11y_audit.config.set_rules({
+        "ignore": ['badAriaAttributeValue', 'imagesWithoutAltText'],
+    })
 
 
 (Optional) Define the Scope of Accessibility Auditing for a Page
@@ -99,9 +97,9 @@ an accessibility audit.
         def __init__(self, *args, **kwargs):
             super(MyPage, self).__init__(*args, **kwargs)
 
-            self.a11y_audit.config.set_rules(
-                ['badAriaAttributeValue', 'imagesWithoutAltText']
-            )
+            self.a11y_audit.config.set_rules({
+                "apply": ['badAriaAttributeValue', 'imagesWithoutAltText'],
+            })
 
         def url(self):
             return 'https://www.mysite.com/page'
@@ -149,9 +147,9 @@ specific accessibility rules.
         def __init__(self, *args, **kwargs):
             super(MyPage, self).__init__(*args, **kwargs)
 
-            self.a11y_audit.config.set_rules(
-                ['badAriaAttributeValue', 'imagesWithoutAltText']
-            )
+            self.a11y_audit.config.set_rules({
+               "apply": ['badAriaAttributeValue', 'imagesWithoutAltText']
+            })
 
         def url(self):
             return 'https://www.mysite.com/page'

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -89,7 +89,7 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_no_rules(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(None)
+        page.a11y_audit.config.set_rules({"apply": None,})
         page.visit()
         report = page.a11y_audit.do_audit()
         self.assertIsNone(report)
@@ -137,7 +137,7 @@ class AxsAccessibilityTest(WebAppTest):
         page = AccessibilityPage(self.browser)
 
         # Limit the rules checked to AX_ARIA_01
-        page.a11y_audit.config.set_rules(['badAriaRole'])
+        page.a11y_audit.config.set_rules({"apply": ['badAriaRole']})
 
         page.visit()
         report = page.a11y_audit.do_audit()
@@ -153,8 +153,9 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_run_multiple_rules(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(
-            ['badAriaRole', 'badAriaAttributeValue'])
+        page.a11y_audit.config.set_rules({
+            "apply": ['badAriaRole', 'badAriaAttributeValue'],
+        })
         page.visit()
         report = page.a11y_audit.do_audit()
 
@@ -174,7 +175,7 @@ class AxsAccessibilityTest(WebAppTest):
 
         # Ignore the rule AX_ARIA_01. For this test, that means the only rule
         # to result in an error should be AX_ARIA_04.
-        page.a11y_audit.config.set_rules(['badAriaRole'], ignore=True)
+        page.a11y_audit.config.set_rules({"ignore": ['badAriaRole']})
 
         page.visit()
         report = page.a11y_audit.do_audit()
@@ -191,10 +192,9 @@ class AxsAccessibilityTest(WebAppTest):
     def test_axs_audit_ignore_multiple_rules(self):
         page = AccessibilityPage(self.browser)
         # Ignore multiple rules. In this test, we are explicitly ignoring each.
-        page.a11y_audit.config.set_rules(
-            ['badAriaRole', 'badAriaAttributeValue'],
-            ignore=True
-        )
+        page.a11y_audit.config.set_rules({
+            "ignore": ['badAriaRole', 'badAriaAttributeValue'],
+        })
 
         page.visit()
         report = page.a11y_audit.do_audit()
@@ -208,8 +208,10 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_ignore_1_and_run_1(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(['badAriaAttributeValue'])
-        page.a11y_audit.config.set_rules(['badAriaRole'], ignore=True)
+        page.a11y_audit.config.set_rules({
+            "apply": ['badAriaAttributeValue'],
+            "ignore": ['badAriaRole'],
+        })
         page.visit()
         report = page.a11y_audit.do_audit()
 
@@ -227,9 +229,10 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_ignore_and_run_same_rule(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(['badAriaRole'])
-        page.a11y_audit.config.set_rules(['badAriaRole'], ignore=True)
-
+        page.a11y_audit.config.set_rules({
+            "apply": ['badAriaRole'],
+            "ignore": ['badAriaRole']
+        })
         page.visit()
         report = page.a11y_audit.do_audit()
 
@@ -247,10 +250,10 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_ignore_1_and_run_2(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(
-            ['badAriaRole', 'badAriaAttributeValue'])
-        page.a11y_audit.config.set_rules(['badAriaRole'], ignore=True)
-
+        page.a11y_audit.config.set_rules({
+            "apply": ['badAriaRole', 'badAriaAttributeValue'],
+            "ignore": ['badAriaRole'],
+        })
         page.visit()
         report = page.a11y_audit.do_audit()
 
@@ -268,9 +271,10 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_ignore_0_and_run_2(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules(
-            ['badAriaRole', 'badAriaAttributeValue'])
-        page.a11y_audit.config.set_rules([], ignore=True)
+        page.a11y_audit.config.set_rules({
+            "apply": ['badAriaRole', 'badAriaAttributeValue'],
+            "ignore": [],
+        })
 
         page.visit()
         report = page.a11y_audit.do_audit()
@@ -288,8 +292,10 @@ class AxsAccessibilityTest(WebAppTest):
 
     def test_axs_audit_ignore_0_and_run_all(self):
         page = AccessibilityPage(self.browser)
-        page.a11y_audit.config.set_rules([])
-        page.a11y_audit.config.set_rules([], ignore=True)
+        page.a11y_audit.config.set_rules({
+            "apply": [],
+            "ignore": [],
+        })
         page.visit()
         report = page.a11y_audit.do_audit()
 
@@ -349,15 +355,21 @@ class AxeCoreAccessibilityTest(WebAppTest):
         self._do_audit_and_check_errors(6)
 
     def test_ignored_rule(self):
-        self.page.a11y_audit.config.set_rules(['aria-roles'], ignore=True)
+        self.page.a11y_audit.config.set_rules({
+            "ignore": ['aria-roles'],
+        })
         self._do_audit_and_check_errors(4)
 
     def test_limited_rules(self):
-        self.page.a11y_audit.config.set_rules(['aria-roles'])
+        self.page.a11y_audit.config.set_rules({
+            "apply": ['aria-roles'],
+        })
         self._do_audit_and_check_errors(2)
 
     def test_limited_rule_tags(self):
-        self.page.a11y_audit.config.set_rules(['wcag111'], include_type="tag")
+        self.page.a11y_audit.config.set_rules({
+            "tags": ['wcag111'],
+        })
         self._do_audit_and_check_errors(1)
 
     def test_exclude_scope(self):
@@ -369,13 +381,6 @@ class AxeCoreAccessibilityTest(WebAppTest):
         self._do_audit_and_check_errors(1)
 
     def test_include_and_exclude_scope(self):
-        self.page.a11y_audit.config.set_scope(
-            exclude=['#limit_scope'],
-            include=['#bad-link']
-        )
-        self._do_audit_and_check_errors(1)
-
-    def test_set_rules_and_scope(self):
         self.page.a11y_audit.config.set_scope(
             exclude=['#limit_scope'],
             include=['#bad-link']


### PR DESCRIPTION
@jzoldak @benpatterson  I refactored the `set_rules` method as we were talking about this morning, partly just as an exercise for myself to see it in place.   Seeing the implementations side by side,  I think either way is fine.   It seems to me that both implementations are probably going to have confusing points for end users, but if this way is going to be easier to maintain down the road, then it is probably good to update.   Let me know what you think.