### PR TITLE
allow A11yAudits to run on browsers other than phantomjs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
 source = bok_choy
+
+[report]
+exclude_lines =
+   pragma: no cover
+   raise NotImplementedError

--- a/docs/accessibility.rst
+++ b/docs/accessibility.rst
@@ -18,8 +18,6 @@ following steps.
   * Actively: `Trigger an Audit Actively and Assert on the Results Returned`_
   * Passively: `Leverage Your Existing Tests and Fail on Accessibility Errors`_
 
-.. note:: Accessibility auditing is only supported with PhantomJS as the browser.
-
 
 Define the Accessibility Rules to Check for a Page
 --------------------------------------------------

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -23,12 +23,19 @@ performance
 
 accessibility
 -------------
+
+A11yAudit and A11yAuditConfig (Abstract Classes)
+________________________________________________
 .. automodule:: bok_choy.a11y.a11y_audit
    :members:
 
+AxsAudit and AxsAuditConfig
+___________________________
 .. automodule:: bok_choy.a11y.axs_ruleset
    :members:
 
+AxeCoreAudit and AxeCoreAuditConfig
+___________________________________
 .. automodule:: bok_choy.a11y.axe_core_ruleset
    :members:
 


### PR DESCRIPTION
I've run into some issues with phantomjs when running the edx-platform tests.  I think these could easily affect others that may want to use the a11y feature as well.

__The two main issues I uncovered:__
*  PhantomJS 1.9.8 runs on an older version of JavaScriptCore, which lacks the method `Function.prototype.bind` (a pretty commonly used method).  PhantomJS 2.0 has the newer version of JavaScriptCore, so this wouldn't be an issue if we could upgrade.  Unfortunately, there is still no binary package available for Linux for version 2.0.  This issue will likely continue to be a problem for a while. 
* PhantomJS doesn't support HTML5 video player (the favored player in platform) or Flash (the fallback player in platform).  It doesn't appear that this will be supported in the future.


__The solution here:__  An implementation of A11yAudit that doesn't _require_ PhantomJS.

__Implementation:__  Previously, we performed an A11yAudit by using PhantomJS' injectJs method to inject the auditing library's javascript code, and then sending a request to PhantomJS to execute the JS audit code and return the results.  The changes here bypasses this by using the `browser.execute_script` method, including the necessary library code in the script. 


@benpatterson @jzoldak  Please review.

FYI, the decrease in coverage is because I removed some large chunks of code.  The uncovered lines are the same ones as before --  the `raise NotImplementedError` lines.