### PR TITLE
add BrowserQuery is_focused method and focused property

### DIFF
--- a/bok_choy/query.py
+++ b/bok_choy/query.py
@@ -445,6 +445,25 @@ class BrowserQuery(Query):
         """
         return self.present and not self.visible
 
+    def is_focused(self):
+        """
+        Checks that _at least one_ matched element is focused. More
+        specifically, it checks whether the element is document.activeElement.
+        If no matching element is focused, this returns `False`.
+
+        Returns:
+            bool
+        """
+        active_el = self.browser.execute_script("return document.activeElement")
+        query_results = self.map(lambda el: el == active_el, 'focused').results
+
+        if query_results:
+            return any(query_results)
+        else:
+            return False
+
+    focused = property(is_focused)
+
     def click(self):
         """
         Click each matched element.

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -217,6 +217,16 @@ class NextPage(SitePage):
         page.visit()
 
 
+class FocusedPage(SitePage):
+    """
+    Page that has a link to a focusable element.
+    """
+    name = "focused"
+
+    def focus_on_main_content(self):
+        self.browser.execute_script("$('#main-content').focus()")
+
+
 class VisiblePage(SitePage):
     """
     Page that has some elements visible and others invisible.

--- a/tests/site/focused.html
+++ b/tests/site/focused.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Focused</title>
+    <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
+</head>
+<body>
+    <div id="main-content" tabindex="-1">some focusable content</div>
+</body>
+</html>

--- a/tests/test_focused.py
+++ b/tests/test_focused.py
@@ -1,0 +1,25 @@
+"""
+Test element "is_focused" functionality.
+"""
+
+from bok_choy.web_app_test import WebAppTest
+from .pages import FocusedPage
+
+
+class FocusedTest(WebAppTest):
+    """
+    Test query `is_focused` method and `focused` property.
+    """
+    def setUp(self):
+        super(FocusedTest, self).setUp()
+        self.page = FocusedPage(self.browser).visit()
+
+    def test_focused(self):
+        self.assertFalse(self.page.q(css="#nonexistent").focused)
+        self.assertFalse(self.page.q(css="#main-content").focused)
+        self.page.focus_on_main_content()
+        self.page.wait_for(
+            self.page.q(css="#main-content").is_focused,
+            "main content should be focused"
+        )
+


### PR DESCRIPTION
@benpatterson @jzoldak  Please review.  I'm hoping to merge this and add it to the 0.4.7 release.  I know I've already seen (and implemented) a few workarounds for the lack of an `is_focused` method.  Since we're starting to test for focus issues more regularly, it would be really useful to have a standard way of doing it that is in line with the other patterns in bok choy.