### PR TITLE
Improve check for custom rules file format

### DIFF
--- a/bok_choy/a11y/axe_core_ruleset.py
+++ b/bok_choy/a11y/axe_core_ruleset.py
@@ -197,9 +197,9 @@ class AxeCoreAuditConfig(A11yAuditConfig):
         with open(custom_file, "r") as additional_rules:
             custom_rules = additional_rules.read()
 
-        if not custom_rules.startswith("var customRules"):
+        if not "var customRules" in custom_rules:
             raise A11yAuditConfigError(
-                "Custom rules file must start with \"var customRules\""
+                "Custom rules file must include \"var customRules\""
             )
 
         self.custom_rules = custom_rules


### PR DESCRIPTION
@benpatterson @jzoldak  Please review.  

Checking that the custom rules file started with "var customRules" was too strict, preventing even having comments at the top of the file.  Instead, this checks that "var customRules" is somewhere in the file, but not necessarily the first thing in it.