### PR TITLE
Capability for scrolling to an element.

### DIFF
--- a/bok_choy/page_object.py
+++ b/bok_choy/page_object.py
@@ -564,3 +564,28 @@ class PageObject(object):
 
         """
         self.wait_for(lambda: self.q(css=element_selector).invisible, description=description, timeout=timeout)
+
+    @unguarded
+    def scroll_to_element(self, element_selector, timeout=60):
+        """
+        Scrolls browser such that the element specified appears at the top. Before scrolling, waits for
+        the element to be present.
+
+        Example usage:
+
+        .. code:: python
+
+            self.scroll_to_element('.far-down', 'Scroll to far-down')
+
+        Arguments:
+            element_selector (str): css selector of the element.
+            timeout (float): Maximum number of seconds to wait for the Promise to be satisfied before timing out
+
+        """
+        # Ensure element exists
+        msg = "Element '{element}' is present".format(element=element_selector)
+        self.wait_for(lambda: self.q(css=element_selector).present, msg, timeout=timeout)
+
+        # Obtain coordinates and use those for JavaScript call
+        loc = self.q(css=element_selector).first.results[0].location
+        self.browser.execute_script("window.scrollTo({x},{y})".format(x=loc['x'], y=loc['y']))

--- a/bok_choy/page_object.py
+++ b/bok_choy/page_object.py
@@ -568,7 +568,7 @@ class PageObject(object):
     @unguarded
     def scroll_to_element(self, element_selector, timeout=60):
         """
-        Scrolls browser such that the element specified appears at the top. Before scrolling, waits for
+        Scrolls the browser such that the element specified appears at the top. Before scrolling, waits for
         the element to be present.
 
         Example usage:
@@ -579,7 +579,10 @@ class PageObject(object):
 
         Arguments:
             element_selector (str): css selector of the element.
-            timeout (float): Maximum number of seconds to wait for the Promise to be satisfied before timing out
+            timeout (float): Maximum number of seconds to wait for the element to be present on the
+                page before timing out.
+
+        Raises: BrokenPromise if the element does not exist (and therefore scrolling to it is not possible)
 
         """
         # Ensure element exists

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,7 +14,7 @@ function echo_task {
 }
 
 REPO_ROOT=`dirname $BASH_SOURCE`
-SERVER_PORT=8003
+SERVER_PORT=8005
 
 export BOK_CHOY_HAR_DIR=$REPO_ROOT/hars
 export LOG_DIR=$REPO_ROOT/logs

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -16,7 +16,7 @@ class SitePage(PageObject):
 
     # Get the server port from the environment
     # (set by the test runner script)
-    SERVER_PORT = os.environ.get("SERVER_PORT", 8003)
+    SERVER_PORT = os.environ.get("SERVER_PORT", 8005)
 
     def is_browser_on_page(self):
         title = self.name.lower().replace('_', ' ')
@@ -375,3 +375,10 @@ class ImagePage(SitePage):
     Page for testing image capture and comparison.
     """
     name = "image"
+
+
+class LongPage(SitePage):
+    """
+    Page that requires scrolling to get to certain elements.
+    """
+    name = "long_page"

--- a/tests/site/long_page.html
+++ b/tests/site/long_page.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Long Page</title>
+    <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script>
+        $(document).ready(function() {
+            $("#fixture input").click(function(theEvent) {
+                $("#output").html("button was clicked");
+            });
+        });
+    </script>
+
+</head>
+<body>
+    <p id="long_part"></p>
+    <p id="element_after_long_part">scroll here</p>
+    <p id="next_long_part"></p>
+    <script>
+        counter = 0;
+        content = ' ';
+        while (counter < 100) { content = content + counter + "<br>"; counter++; }
+        document.getElementById("long_part").innerHTML = content;
+    </script>
+    <script>
+        counter = 100;
+        content = ' ';
+        while (counter < 200) { content = content + counter + "<br>"; counter++; }
+        document.getElementById("next_long_part").innerHTML = content;
+    </script>
+
+</body>
+</html>

--- a/tests/site/long_page.html
+++ b/tests/site/long_page.html
@@ -5,29 +5,22 @@
     <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
     <script>
         $(document).ready(function() {
-            $("#fixture input").click(function(theEvent) {
-                $("#output").html("button was clicked");
-            });
+            counter = 0;
+            content = ' ';
+            while (counter < 100) { content = content + counter + "<br>"; counter++; }
+            document.getElementById("long_part").innerHTML = content;
+            counter = 100;
+            content = ' ';
+            while (counter < 200) { content = content + counter + "<br>"; counter++; }
+            document.getElementById("next_long_part").innerHTML = content;
         });
     </script>
-
+    <script>
+    </script>
 </head>
 <body>
     <p id="long_part"></p>
     <p id="element_after_long_part">scroll here</p>
     <p id="next_long_part"></p>
-    <script>
-        counter = 0;
-        content = ' ';
-        while (counter < 100) { content = content + counter + "<br>"; counter++; }
-        document.getElementById("long_part").innerHTML = content;
-    </script>
-    <script>
-        counter = 100;
-        content = ' ';
-        while (counter < 200) { content = content + counter + "<br>"; counter++; }
-        document.getElementById("next_long_part").innerHTML = content;
-    </script>
-
 </body>
 </html>

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -4,6 +4,8 @@ Tests for retrieving values from the page using CSS selectors.
 
 from bok_choy.web_app_test import WebAppTest
 from .pages import SelectorPage
+from .pages import LongPage
+from bok_choy.promise import BrokenPromise
 
 
 class SelectorTest(WebAppTest):
@@ -49,3 +51,33 @@ class SelectorTest(WebAppTest):
     def test_filtered_query_no_match(self):
         outer_id_list = self.selector.ids_of_outer_divs_with_inner_text('This does not match anything')
         self.assertEquals(outer_id_list, [])
+
+
+class ScrollTest(WebAppTest):
+    """
+    Test scrolling to element
+    """
+
+    def setUp(self):
+        super(ScrollTest, self).setUp()
+
+        self.long_page = LongPage(self.browser)
+        self.long_page.visit()
+
+    def test_scroll(self):
+        self.assertEquals(self._get_window_position(), 0)
+        self.long_page.scroll_to_element('#element_after_long_part')
+        # Different browsers, CI systems, and resolutions may present the
+        # element in varying locations. Use a greater-than instead of an equals.
+        self.assertGreaterEqual(self._get_window_position(), 1900)
+
+    def test_scroll_false_element(self):
+        """
+        When scroll_to_element is given a non-existent element, it should
+        raise a BrokenPromise
+        """
+        with self.assertRaises(BrokenPromise):
+            self.long_page.scroll_to_element('.foo', timeout=1)
+
+    def _get_window_position(self):
+        return self.browser.execute_script("return window.scrollY;")


### PR DESCRIPTION
Sometimes an element is not clickable because it is not in the viewport. However,
tests like `<query_object>.present` or `<query_object>.visible` will return
`True`.This change provides the capability for scrolling to an element in the
viewport.