### PR TITLE
specify python version compatibilty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@
 
 from setuptools import setup
 
-VERSION = '0.4.10'
+VERSION = '0.4.11'
 DESCRIPTION = 'UI-level acceptance test framework'
-REQUIREMENTS = [
-    line.strip() for line in open("requirements.txt").readlines()
-]
+with open('requirements.txt') as f:
+    REQUIREMENTS = f.read().splitlines()
 
 setup(
     name='bok_choy',
@@ -21,6 +20,8 @@ setup(
                  'License :: OSI Approved :: Apache Software License',
                  'Operating System :: OS Independent',
                  'Programming Language :: Python',
+                 'Programming Language :: Python :: 2',
+                 'Programming Language :: Python :: 2.7',
                  'Topic :: Software Development :: Testing',
                  'Topic :: Software Development :: Quality Assurance'],
     packages=['bok_choy', 'bok_choy/a11y'],


### PR DESCRIPTION
The main purpose of this PR is to specify which version of Python that bok-choy requires.  This is typically done via trove classifiers in setup.py. (this information should probably also be added to the docs under installation instructions)

This PR also contains some very minor tweaks to setup.py (see below)

----

changes:

  * setup.py: specified python version compatibilty in classifiers
  * setup.py: rewrote the way requirements.txt is parsed to be more Pythonic.  The old code also leaked a file descriptor since it never closed requirements.txt after reading.
  * setup.py: bumped version number from 0.4.10 -> 0.4.11 since 0.4.10 has already been released