### PR TITLE
Disable welcome tab on firefox profiles.

### DIFF
--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -232,6 +232,12 @@ def _local_browser_class(browser_name):
             # access a media device (e.g., a webcam)
             firefox_profile.set_preference('media.navigator.permission.disabled', True)
 
+            # Disable the initial url fetch to 'learn more' from mozilla (so you don't have to
+            # be online to run bok-choy on firefox)
+            firefox_profile.set_preference('browser.startup.homepage', 'about:blank')
+            firefox_profile.set_preference('startup.homepage_welcome_url', 'about:blank')
+            firefox_profile.set_preference('startup.homepage_welcome_url.additional', 'about:blank')
+
             browser_args = []
             browser_kwargs = {
                 'firefox_profile': firefox_profile,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -17,6 +17,18 @@ class TestBrowser(TestCase):
         self.addCleanup(browser.quit)
         self.assertIsInstance(browser, webdriver.Firefox)
 
+    @patch.dict(os.environ, {'SELENIUM_BROWSER': 'firefox'})
+    def test_firefox_preferences(self):
+        browser = bok_choy.browser.browser()
+        self.addCleanup(browser.quit)
+        # In-spite of the name, 'default_preferences' represents the preferences
+        # that are in place on the browser. (The underlying preferences start
+        # with default_preferences and are updated in-place.)
+        preferences = browser.profile.default_preferences
+        self.assertEqual(preferences['browser.startup.homepage'], 'about:blank')
+        self.assertEqual(preferences['startup.homepage_welcome_url'], 'about:blank')
+        self.assertEqual(preferences['startup.homepage_welcome_url.additional'], 'about:blank')
+
     @patch.dict(os.environ, {'SELENIUM_BROWSER': 'phantomjs'})
     def test_phantom_browser(self):
         browser = bok_choy.browser.browser()

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -60,7 +60,6 @@ class ScrollTest(WebAppTest):
 
     def setUp(self):
         super(ScrollTest, self).setUp()
-
         self.long_page = LongPage(self.browser)
         self.long_page.visit()
 


### PR DESCRIPTION
This tab can cause profile loading failures if the developer
is offline or has a poor internet connection. That means
s/he can't test against localhost. Setting the firefox
profile to always load with that page disabled.