### PR TITLE
Generalize the XSS false positives check.

### DIFF
--- a/tests/site/xss_safe.html
+++ b/tests/site/xss_safe.html
@@ -10,6 +10,8 @@
     <div id="fixture">
         <div class="escaped">&#39;&#39;;!--&#34;&lt;XSS&gt;=&amp;{()}</div>
         <input type="text" value="&#39;&#39;;!--&#34;&lt;XSS&gt;=&amp;{()}">
+        <article aria-label="&#39;&#39;;!--&#34;&lt;XSS&gt;=&amp;{()}"></article>
+        <img src="foo.jpg" alt="&#39;&#39;;!--&#34;&lt;XSS&gt;=&amp;{()}">
     </div>
 </body>
 </html>


### PR DESCRIPTION
While working on cleaning up a set of templates, I found that false positives were not limited to the value attribute of the input tag (see https://github.com/edx/edx-platform/pull/11926).

@robrap and I decided the best thing was just to allow the very specific escaping that we get from such an attribute field (as returned by the document method).

I verified that we do not lose any actual failures with this change (https://build.testeng.edx.org/view/edx-platform-specific-tests/job/edx-platform-bok-choy-custom/255/#showFailuresLink).

Ticket: https://openedx.atlassian.net/browse/TNL-4295

Please review @jzoldak and @robrap 
Note that I will want to release a new version of bok choy after this.
