### PR TITLE
Make browser instantiation more resilient.

### DIFF
--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -207,7 +207,10 @@ def browser(tags=None, proxy=None):
             return False, None
 
     browser_instance = Promise(
-        browser_check_func, "Browser is instantiated successfully.", try_limit=3).fulfill()
+        # There are cases where selenium takes 30s to return with a failure, so in order to try 3
+        # times, we set a long timeout. If there is a hang on the first try, the timeout will
+        # be enforced.
+        browser_check_func, "Browser is instantiated successfully.", try_limit=3, timeout=95).fulfill()
 
     return browser_instance
 


### PR DESCRIPTION
The underlying selenium function that results in the "Can't load profile"
error is a 30-second polling function. Since that is also our default
timeout setting, bok-choy never gets a chance to retry. (That is, it takes
30 seconds for selenium to produce the WebDriverException). This gives
the driver another chance to create  browser instance when previously it
would only try once and fail. That was not the intention of the original
change with a `try_limit`. This also overrides the default timeout to
60 seconds due to the underlying timeout in selenium.