### PR TITLE
Adds impact to the error output

### DIFF
--- a/bok_choy/a11y/axe_core_ruleset.py
+++ b/bok_choy/a11y/axe_core_ruleset.py
@@ -349,6 +349,7 @@ class AxeCoreAudit(A11yAudit):
 
         lines = []
         for error_type in errors:
+            lines.append("Severity: {}".format(error_type.get("impact")))
             lines.append("Rule ID: {}".format(error_type.get("id")))
             lines.append("Help URL: {}\n".format(error_type.get('helpUrl')))
 


### PR DESCRIPTION
I recently added a few [new checks to our custom ruleset](https://github.com/edx/edx-custom-a11y-rules/pull/3) listed as "minor" severity. While the failures will cause Jenkins to fail, it will indicate to developers and PR reviewers that the failures, if "minor" severity, can be skipped at this time.

This work relates to [this comment](https://github.com/edx/edx-custom-a11y-rules/pull/3#discussion_r65388499).

> Ok, I hear you. I think you are addressing the point of failing or not-failing, which makes sense. But I guess I'm wondering, how would a developer know if the issue is minor or critical when running tests? Is there any hint to give that indication (other than the fail or pass overall)?

## Reviewer

- [x] @benpatterson 