### PR TITLE
Version bump to include a11y-rules in platform (v0.5.3)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Jonathan Piacenti <kelketek@gmail.com>
 Christina Roberts <christina@edx.org>
 Bill Agee <billagee@gmail.com>
 Carol Tong <ctong@edx.org>
+Chris Rodriguez <edx@chrisrodriguez.me>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.5.3 (06/07/16)
+* Updated the a11y-custom-rules output to include the severity of the a11y failure
+* Added Chris Rodriguez to AUTHORS file
+
 v0.5.2 (04/25/16)
 * Support Opera browser
 * Improve browser instantiation logic to include retries

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,9 +38,9 @@ copyright = u'2016, EdX'
 # built documents.
 #
 # The short X.Y version.
-version = '0.5.2'
+version = '0.5.3'
 # The full version, including alpha/beta/rc tags.
-release = '0.5.2'
+release = '0.5.3'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-VERSION = '0.5.2'
+VERSION = '0.5.3'
 DESCRIPTION = 'UI-level acceptance test framework'
 with open('requirements.txt') as f:
     REQUIREMENTS = f.read().splitlines()


### PR DESCRIPTION
@benpatterson I guess I should've included this work with the previously merged PR. Doh! The working example I tested with was using a manual Git commit hash/egg, but in order to make this useful to other developers it needs to be permanent :)

- [ ] @benpatterson 