### PR TITLE
Add FIREFOX_PROFILE_PATH option to override default profile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Chris Rodriguez <edx@chrisrodriguez.me>
 Anjali Pal <apal@edx.org>
 Diana Huang <dkh@edx.org>
 Jeremy Bowman <jbowman@edx.org>
+Tyler Hallada <thallada@edx.org>

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -47,6 +47,8 @@ BROWSERS = {
     'opera': NeedleOpera,
 }
 
+FIREFOX_PROFILE_ENV_VAR = 'FIREFOX_PROFILE_PATH'
+
 
 class BrowserConfigError(Exception):
 
@@ -159,13 +161,14 @@ def browser(tags=None, proxy=None):
     1. Local browsers: If the proper environment variables are not all set for the second case,
         then we use a local browser.
 
-        * The environment variable `SELENIUM_BROWSER` can be set to
-          specify which local browser to use. The default is Firefox.
-        * Additionally, if a proxy
-          instance is passed and the browser choice is either Chrome or Firefox, then the browser will
-          be initialized with the proxy server set.
-        * The environment variable `SELENIUM_FIREFOX_PATH` can be used for specifying a path to the
-          Firefox binary. Default behavior is to use the system location.
+        * The environment variable `SELENIUM_BROWSER` can be set to specify which local browser to use. The default is \
+          Firefox.
+        * Additionally, if a proxy instance is passed and the browser choice is either Chrome or Firefox, then the \
+          browser will be initialized with the proxy server set.
+        * The environment variable `SELENIUM_FIREFOX_PATH` can be used for specifying a path to the Firefox binary. \
+          Default behavior is to use the system location.
+        * The environment variable `FIREFOX_PROFILE_PATH` can be used for specifying a path to the Firefox profile. \
+          Default behavior is to use a barebones default profile with a few useful preferences set.
 
     2. Remote browser (not SauceLabs): Set all of the following environment variables, but not all of
         the ones needed for SauceLabs:
@@ -260,7 +263,7 @@ def _local_browser_class(browser_name):
                 name=browser_name, options=", ".join(BROWSERS.keys())))
     else:
         if browser_name == 'firefox':
-            profile_dir = os.environ.get('FIREFOX_PROFILE')
+            profile_dir = os.environ.get(FIREFOX_PROFILE_ENV_VAR)
 
             if profile_dir:
                 LOGGER.info("Using firefox profile: %s", profile_dir)

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -260,17 +260,24 @@ def _local_browser_class(browser_name):
                 name=browser_name, options=", ".join(BROWSERS.keys())))
     else:
         if browser_name == 'firefox':
-            firefox_profile = webdriver.FirefoxProfile()
+            profile_dir = os.environ.get('FIREFOX_PROFILE')
 
-            # Bypasses the security prompt displayed by the browser when it attempts to
-            # access a media device (e.g., a webcam)
-            firefox_profile.set_preference('media.navigator.permission.disabled', True)
+            if profile_dir:
+                LOGGER.info("Using firefox profile: %s", profile_dir)
+                firefox_profile = webdriver.FirefoxProfile(profile_dir)
+            else:
+                LOGGER.info("Using default firefox profile")
+                firefox_profile = webdriver.FirefoxProfile()
 
-            # Disable the initial url fetch to 'learn more' from mozilla (so you don't have to
-            # be online to run bok-choy on firefox)
-            firefox_profile.set_preference('browser.startup.homepage', 'about:blank')
-            firefox_profile.set_preference('startup.homepage_welcome_url', 'about:blank')
-            firefox_profile.set_preference('startup.homepage_welcome_url.additional', 'about:blank')
+                # Bypasses the security prompt displayed by the browser when it attempts to
+                # access a media device (e.g., a webcam)
+                firefox_profile.set_preference('media.navigator.permission.disabled', True)
+
+                # Disable the initial url fetch to 'learn more' from mozilla (so you don't have to
+                # be online to run bok-choy on firefox)
+                firefox_profile.set_preference('browser.startup.homepage', 'about:blank')
+                firefox_profile.set_preference('startup.homepage_welcome_url', 'about:blank')
+                firefox_profile.set_preference('startup.homepage_welcome_url.additional', 'about:blank')
 
             browser_args = []
             browser_kwargs = {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -73,6 +73,22 @@ class TestBrowser(TestCase):
             bok_choy.browser.browser()
         self.assertEqual(patch_object.call_count, 3)
 
+    @patch.dict(os.environ, {'FIREFOX_PROFILE_PATH': '/foo/path'})
+    def test_custom_firefox_profile(self):
+        patch_object = patch.object(webdriver, 'FirefoxProfile').start()
+        self.addCleanup(patch.stopall)
+        browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')
+        self.assertTrue('firefox_profile' in browser_kwargs_tuple[2])
+        patch_object.assert_called_with('/foo/path')
+
+    @patch.dict(os.environ, {'FIREFOX_PROFILE_PATH': ''})
+    def test_no_custom_firefox_profile(self):
+        patch_object = patch.object(webdriver, 'FirefoxProfile').start()
+        self.addCleanup(patch.stopall)
+        browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')
+        self.assertTrue('firefox_profile' in browser_kwargs_tuple[2])
+        patch_object.assert_called_with()
+
     def test_socket_error(self):
         """
         If there is a socket error when instantiating the driver,


### PR DESCRIPTION
Allows overriding the default firefox profile that bok-choy creates with one created by the user. This is useful for setting profile preferences needed for a specific set of tests (e.g. disabling the firefox warning pop-up for a script taking too long for very long running javascript tests).

@ajpal @dianakhuang @jmbowman @jzoldak 