### PR TITLE
v0.5.4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,6 @@ Christina Roberts <christina@edx.org>
 Bill Agee <billagee@gmail.com>
 Carol Tong <ctong@edx.org>
 Chris Rodriguez <edx@chrisrodriguez.me>
+Anjali Pal <apal@edx.org>
+Diana Huang <dkh@edx.org>
+Jeremy Bowman <jbowman@edx.org>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v0.5.4 (06/16/16)
+* Remove browsermobproxy and HAR capture feature
+* Add ability to save browser page source to disk
+* Update from pep8 to pycodestyle
+* Clean up requirements and setup.py, start using tox
+* Build and distribute wheels
+
 v0.5.3 (06/07/16)
 * Updated the a11y-custom-rules output to include the severity of the a11y failure
 * Added Chris Rodriguez to AUTHORS file

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,9 +38,9 @@ copyright = u'2016, EdX'
 # built documents.
 #
 # The short X.Y version.
-version = '0.5.3'
+version = '0.5.4'
 # The full version, including alpha/beta/rc tags.
-release = '0.5.3'
+release = '0.5.4'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import codecs
 from setuptools import setup
 
-VERSION = '0.5.3'
+VERSION = '0.5.4'
 DESCRIPTION = 'UI-level acceptance test framework'
 REQUIREMENTS = (
     'lazy',


### PR DESCRIPTION
@benpatterson 
We're still working on improvements, but I wanted to cut a new release w/o browsermobproxy and to verify packaging and distributing wheels.