### PR TITLE
Firefox profile preferences customization

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -1,0 +1,44 @@
+Browser Customization
+=====================
+
+Although the default browser configurations provided by bok-choy should be
+sufficient for most needs, sometimes you'll need to customize it a little
+for particular tests or even an entire test suite.  Here are some of the
+options bok-choy provides for doing that.
+
+Firefox Profile Preferences
+---------------------------
+
+Whether you use a custom profile or not, you can customize the profile's
+preferences before the browser is launched.  To do this, create a function
+which takes a
+`FirefoxProfile <https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.firefox_profile.html#selenium.webdriver.firefox.firefox_profile.FirefoxProfile>`_
+as a parameter and add it via the
+``bok_choy.browser.add_profile_customizer()`` function.  For example,
+to suppress the "unresponsive script" warning dialog that normally interrupts
+a test case in Firefox when running accessibility tests on a particularly long
+page:
+
+.. code-block:: python
+
+    def customize_preferences(profile):
+        profile.set_preference('dom.max_chrome_script_run_time', 0)
+        profile.set_preference('dom.max_script_run_time', 0)
+    bok_choy.browser.add_profile_customizer(customize_preferences)
+
+This customization can be done in any of the normal places that test setup
+occurs: ``setUpClass()``, a pytest fixture, the test case itself, etc.  You
+can clear any previously-added profile customizers via the
+``bok_choy.browser.clear_profile_customizers()`` function.
+
+Firefox Profile Directory
+-------------------------
+
+Normally, selenium launches Firefox using a new, anonymous user profile.  If
+you have a specific Firefox profile that you'd like to use instead, you can
+specify the path to its directory in the ``FIREFOX_PROFILE_PATH`` environment
+variable anytime before the call to ``bok_choy.browser.browser()``.  This
+passes the path to the
+`FirefoxProfile constructor <https://seleniumhq.github.io/selenium/docs/api/py/webdriver_firefox/selenium.webdriver.firefox.firefox_profile.html#selenium.webdriver.firefox.firefox_profile.FirefoxProfile>`_
+so the browser can be launched with any customizations that have been made to
+that profile.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ UI-level acceptance test framework.
    accessibility
    visual_diff
    xss
+   customization
    api_reference
 
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -31,13 +31,29 @@ class TestBrowser(TestCase):
     def test_firefox_preferences(self):
         browser = bok_choy.browser.browser()
         self.addCleanup(browser.quit)
-        # In-spite of the name, 'default_preferences' represents the preferences
+        # In spite of the name, 'default_preferences' represents the preferences
         # that are in place on the browser. (The underlying preferences start
         # with default_preferences and are updated in-place.)
         preferences = browser.profile.default_preferences
         self.assertEqual(preferences['browser.startup.homepage'], 'about:blank')
         self.assertEqual(preferences['startup.homepage_welcome_url'], 'about:blank')
         self.assertEqual(preferences['startup.homepage_welcome_url.additional'], 'about:blank')
+
+    @patch.dict(os.environ, {'SELENIUM_BROWSER': 'firefox'})
+    def test_customize_firefox_preferences(self):
+        def customize_preferences(profile):
+            profile.set_preference('dom.max_chrome_script_run_time', 0)
+            profile.set_preference('dom.max_script_run_time', 0)
+        bok_choy.browser.add_profile_customizer(customize_preferences)
+        self.addCleanup(bok_choy.browser.clear_profile_customizers)
+        browser = bok_choy.browser.browser()
+        self.addCleanup(browser.quit)
+        # In spite of the name, 'default_preferences' represents the preferences
+        # that are in place on the browser. (The underlying preferences start
+        # with default_preferences and are updated in-place.)
+        preferences = browser.profile.default_preferences
+        assert preferences['dom.max_chrome_script_run_time'] == 0
+        assert preferences['dom.max_script_run_time'] == 0
 
     @patch.dict(os.environ, {'SELENIUM_BROWSER': 'phantomjs'})
     def test_phantom_browser(self):


### PR DESCRIPTION
* Moved configuration of the Firefox profile out into its own function
* Added support for programmatic customization of the Firefox profile preferences in a way that can be reused across test cases
* Added some documentation on both options currently available for customizing the Firefox profile

The immediate motivation for this was incorporating automated accessibility tests into https://github.com/pytube/pytube , where some of the tested pages are long enough that the accessibility tests run afoul of Firefox's default unresponsive script timeout.  The documentation shows how this timeout can be overridden.