### PR TITLE
fix nit in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ To run the test suite for bok-choy itself:
   dependencies
 * Run ``tox -e py27`` (or ``tox -e py35``)
 * To test and build the documentation, run ``tox -e doc``
-* To run an individual test run ``py.test tests/<test file>::TestSaveFiles::<test name>``
+* To run an individual test, run ``py.test tests/<test file>::<test class>::<test name>``
 
 
 License


### PR DESCRIPTION
This PR fixes the instructions for running an individual test by removing the hardcoded `TestSaveFiles` class name... which initially confused the heck out me :)
