### PR TITLE
Support running tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis
 script:
-- tox
+- tox -- -n 2 --durations=10
 - tox -e doc
 after_success:
 - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -30,14 +30,16 @@ Running Tests
 
 To run the test suite for bok-choy itself:
 
-* Install Firefox, `version 46.0.1 <https://ftp.mozilla.org/pub/firefox/releases/46.0.1/>`_
-  or earlier (later versions require a different selenium driver)
+* Install Firefox; as of this writing, the current `version 47.0.1 <https://ftp.mozilla.org/pub/firefox/releases/47.0.1/>`_
+  works with the latest selenium Python package (2.53.6)
 * Install `phantomjs <http://phantomjs.org/download.html>`_
 * Create a virtualenv which uses Python 2.7 (or Python 3.5)
 * With that virtualenv activated, run ``pip install -r requirements/tox.txt`` to
   install the `tox <http://tox.testrun.org/>`_ testing tool and its
   dependencies
-* Run ``tox -e py27`` (or ``tox -e py35``)
+* Run ``tox -e py27`` (or ``tox -e py35``).  If you want to run the tests in
+  parallel, add the desired number of worker processes like ``tox -e py27 -- -n 5``
+  or ``tox -e py35 -- -n auto``.
 * To test and build the documentation, run ``tox -e doc``
 * To run an individual test, run ``py.test tests/<test file>::<test class>::<test name>``
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,8 +2,8 @@
 
 # needle (selenium is also used directly)
 nose==1.3.7
-Pillow==3.2.0
-selenium==2.53.5
+Pillow==3.3.0
+selenium==2.53.6
 
 # Then the direct dependencies
 
@@ -12,3 +12,6 @@ lazy==1.2
 
 # For test assertions involving screenshots and visual diffs
 needle==0.3
+
+# For Python 2 & 3 compatibility
+six==1.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,26 +10,31 @@ wrapt==1.10.8
 # cov-core
 coverage==4.1
 
+# execnet
+apipkg==1.4
+
 # pylint
 colorama==0.3.7
 
 # pylint-plugin-utils
-astroid==1.4.6
+astroid==1.4.7
 pylint==1.5.6
 
 # pylint-celery, pylint-django
-pylint-plugin-utils
+pylint-plugin-utils==0.2.4
 
 # edx-lint
 pylint-celery==0.3
 pylint-django==0.7.2
 
-# pytest
+# pytest, pytest-xdist
 py==1.4.31
 
-# pytest-cov
-cov-core==1.15.0
+# pytest-cov, pytest-xdist
 pytest==2.9.2
+
+# pytest-xdist
+execnet==1.4.1
 
 # Then the direct dependencies
 
@@ -47,3 +52,6 @@ pytest-catchlog==1.2.2
 
 # For code coverage statistics generation
 pytest-cov==2.2.1
+
+# For parallel test execution
+pytest-xdist==1.14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,15 @@ def pytest_configure(config):  # pylint: disable=unused-argument
         os.environ['SCREENSHOT_DIR'] = REPO_ROOT
     if 'SELENIUM_DRIVER_LOG_DIR' not in os.environ:
         os.environ['SELENIUM_DRIVER_LOG_DIR'] = REPO_ROOT
-    if 'SERVER_PORT' not in os.environ:
-        os.environ['SERVER_PORT'] = '8005'
+    if 'SERVER_PORT' not in os.environ and not hasattr(config, 'slaveinput'):
+        config.server_ports = [str(port) for port in range(8020, 8040)]
+        # In case we're only using one node
+        os.environ['SERVER_PORT'] = '8020'
+
+
+def pytest_configure_node(node):
+    """Give each test node a distinct HTTP port to use"""
+    os.environ['SERVER_PORT'] = node.config.server_ports.pop()
 
 
 @pytest.fixture(scope='session')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ passenv =
 setenv =
     SCREENSHOT_DIR={toxinidir}/logs
     SELENIUM_DRIVER_LOG_DIR={toxinidir}/logs
-    SERVER_PORT=8005
 whitelist_externals =
     mkdir
     rm
@@ -30,7 +29,7 @@ commands =
     pycodestyle tests
     mkdir -p $SELENIUM_DRIVER_LOG_DIR
     rm -rf $SELENIUM_DRIVER_LOG_DIR/*
-    py.test {posargs:tests}
+    py.test {posargs:tests} --durations=10
 
 [testenv:doc]
 deps =


### PR DESCRIPTION
Added support for running tests in parallel via pytest-xdist.  On my local machine, this impacts test duration with increasing number of worker processes as follows:

1 node: 361.16 seconds
2 nodes: 216.78 seconds
3 nodes: 169.27 seconds
4 nodes: 147.60 seconds
5 nodes: 145.69 seconds
6 nodes: 148.79 seconds

Travis VMs oficially have 1.5 cores, so this should see a little bit of a speedup there also.  Note that a separate HTTP server is launched for each test process; trying to instantiate just one to share between them didn't seem to fit well with the startup hook sequence (partially because pytest-xdist is also intended to support distributing work across test processes on different machines).

Other changes made:

* List the 10 slowest test cases from each run so optimization efforts can be focused on them
* Updated a few dependencies for test runs
* Updated the README to reflect that the latest Firefox and selenium currently work together