### PR TITLE
Make all Bok Choy tests show long failure messages

### DIFF
--- a/bok_choy/web_app_test.py
+++ b/bok_choy/web_app_test.py
@@ -27,6 +27,9 @@ class WebAppTest(NeedleTestCase):
     def __init__(self, *args, **kwargs):
         super(WebAppTest, self).__init__(*args, **kwargs)
 
+        # Make all test failures show actual and expected values
+        self.longMessage = True  # pylint: disable=invalid-name
+
         # This allows using the @attr() decorator from nose to set these on a
         # test by test basis
         self.proxy = getattr(self, 'proxy', None)


### PR DESCRIPTION
@jzoldak @benpatterson this is a simple change to improve failure messages for Bok Choy failures. See this Stack Overflow article for the reasoning:

http://stackoverflow.com/questions/4634625/python-can-unittest-display-expected-and-actual-values

This has been bothering me for a while, when we see Jenkins failures with no indication of what the actual and expected values were.