### PR TITLE
Update Sphinx docs to edX theme, fix doc test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ nosetests.xml
 .project
 .pydevproject
 
+# PyCharm
+.idea
+
 # Sphinx
 docs/_build
 docs/**/*.png

--- a/docs/code/round_3/pages.py
+++ b/docs/code/round_3/pages.py
@@ -21,7 +21,7 @@ class GitHubSearchResultsPage(PageObject):
         """
         Return a list of results returned from a search
         """
-        return self.q(css='ul.repo-list > li > h3.repo-list-name > a').text
+        return self.q(css='ul.repo-list > li > div > h3 > a').text
 
 
 class GitHubSearchPage(PageObject):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import sys, os
+import os
+import sys
+import edx_theme
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -11,7 +14,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'edx_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -31,7 +34,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'bok-choy'
-copyright = u'2016, EdX'
+copyright = edx_theme.COPYRIGHT
+author = edx_theme.AUTHOR
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -54,7 +58,9 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'edx_theme'
+html_theme_path = [edx_theme.get_html_theme_path()]
+html_favicon = os.path.join(html_theme_path[0], 'edx_theme', 'static', 'css', 'favicon.ico')
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'bok-choydoc'
@@ -68,7 +74,7 @@ latex_elements = {}
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'bok-choy.tex', u'bok-choy Documentation',
-   u'EdX', 'manual'),
+   author, 'manual'),
 ]
 
 
@@ -78,7 +84,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'bok-choy', u'bok-choy Documentation',
-     [u'EdX'], 1)
+     [author], 1)
 ]
 
 
@@ -89,7 +95,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'bok-choy', u'bok-choy Documentation',
-   u'EdX', 'bok-choy', 'One line description of project.',
+   author, 'bok-choy', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,10 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
+
+# Note that to get setup.py to work correctly with needle we have
+# version constraints specified in setup.py as well. We will need
+# to change both to upgrade to selenium 3 or above.
 selenium==2.53.6
 
 # Then the direct dependencies

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,6 +23,7 @@ babel==2.3.4
 imagesize==0.7.1
 Jinja2==2.8
 snowballstemmer==1.2.1
+edx-sphinx-theme==1.0.2
 
 # Then the direct dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,13 @@ from setuptools import setup
 
 VERSION = '0.6.0'
 DESCRIPTION = 'UI-level acceptance test framework'
+
+# Version for selenium added since needle has a max version which is lower than the current default. If needle ever
+# revs to a higher version (currently needle is 0.3) we should remove this.
 REQUIREMENTS = (
     'lazy',
     'needle',
-    'selenium',
+    'selenium==2.53.6',
     'six',
 )
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = 'UI-level acceptance test framework'
 REQUIREMENTS = (
     'lazy',
     'needle',
-    'selenium==2.53.6',
+    'selenium>=2,<3',
     'six',
 )
 


### PR DESCRIPTION
PLAT-1087 - Update the Sphinx docs to use the theme from the  edx-sphinx-theme repo. Also ran into an issue with the docs tests that is unrelated but may have failed on commit so I fixed that too. Problem just seems to have been that GitHub changed their html layout.

@jmbowman @jzoldak - please take a look when you get a chance.