### PR TITLE
Update needle version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis
 script:
-- tox -- --durations=10
+- tox -- -n 2 --durations=10
 - tox -e doc
 after_success:
 - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,9 @@ To run the test suite for bok-choy itself:
 * With that virtualenv activated, run ``pip install -r requirements/tox.txt`` to
   install the `tox <http://tox.testrun.org/>`_ testing tool and its
   dependencies
-* Run ``tox -e py27`` (or ``tox -e py35``).
+* Run ``tox -e py27`` (or ``tox -e py35``).  If you want to run the tests in
+  parallel, add the desired number of worker processes like ``tox -e py27 -- -n 5``
+  or ``tox -e py35 -- -n auto``.
 * To test and build the documentation, run ``tox -e doc``
 * To run an individual test, run ``py.test tests/<test file>::<test class>::<test name>``
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ selenium==2.53.6
 lazy==1.2
 
 # For test assertions involving screenshots and visual diffs
-needle==0.3
+needle==0.4.1
 
 # For Python 2 & 3 compatibility
 six==1.10.0


### PR DESCRIPTION
@jmbowman @cgoldberg @edx/testeng 

The change was merged upstream, and a new release was cut. 
https://github.com/bfirsh/needle/pull/57
We should be safe for multiprocess again.