### PR TITLE
Firefox improvements in logging and default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/_build
 docs/**/*.png
 
 # Output from tests
+.cache
 screenshots
 logs
 ghostdriver.log

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -323,11 +323,22 @@ def _local_browser_class(browser_name):
             browser_kwargs = {
                 'firefox_profile': _firefox_profile(),
             }
-            if os.environ.get('SELENIUM_FIREFOX_PATH', None):
-                binary_kwarg = {
-                    'firefox_binary': FirefoxBinary(firefox_path=os.environ.get('SELENIUM_FIREFOX_PATH'))
-                }
-                browser_kwargs.update(binary_kwarg)
+
+            firefox_path = os.environ.get('SELENIUM_FIREFOX_PATH')
+            firefox_log = os.environ.get('SELENIUM_FIREFOX_LOG')
+            if firefox_path and firefox_log:
+                browser_kwargs.update({
+                    'firefox_binary': FirefoxBinary(
+                        firefox_path=firefox_path, log_file=firefox_log)
+                })
+            elif firefox_path:
+                browser_kwargs.update({
+                    'firefox_binary': FirefoxBinary(firefox_path=firefox_path)
+                })
+            elif firefox_log:
+                browser_kwargs.update({
+                    'firefox_binary': FirefoxBinary(log_file=firefox_log)
+                })
 
         elif browser_name == 'chrome':
             chrome_options = Options()

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -298,6 +298,22 @@ def _firefox_profile():
         firefox_profile.set_preference('browser.startup.homepage', 'about:blank')
         firefox_profile.set_preference('startup.homepage_welcome_url', 'about:blank')
         firefox_profile.set_preference('startup.homepage_welcome_url.additional', 'about:blank')
+
+        # Disable fetching an updated version of firefox
+        firefox_profile.set_preference('app.update.enabled', False)
+
+        # Disable plugin checking
+        firefox_profile.set_preference('plugins.hide_infobar_for_outdated_plugin', True)
+
+        # Disable health reporter
+        firefox_profile.set_preference('datareporting.healthreport.service.enabled', False)
+
+        # Disable all data upload (Telemetry and FHR)
+        firefox_profile.set_preference('datareporting.policy.dataSubmissionEnabled', False)
+
+        # Disable crash reporter
+        firefox_profile.set_preference('toolkit.crashreporter.enabled', False)
+
     for function in FIREFOX_PROFILE_CUSTOMIZERS:
         function(firefox_profile)
     return firefox_profile

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -40,6 +40,11 @@ class TestBrowser(TestCase):
         self.assertEqual(preferences['browser.startup.homepage'], 'about:blank')
         self.assertEqual(preferences['startup.homepage_welcome_url'], 'about:blank')
         self.assertEqual(preferences['startup.homepage_welcome_url.additional'], 'about:blank')
+        self.assertFalse(preferences['app.update.enabled'])
+        self.assertTrue(preferences['plugins.hide_infobar_for_outdated_plugin'])
+        self.assertFalse(preferences['datareporting.healthreport.service.enabled'])
+        self.assertFalse(preferences['datareporting.policy.dataSubmissionEnabled'])
+        self.assertFalse(preferences['toolkit.crashreporter.enabled'])
 
     @patch.dict(os.environ, {'SELENIUM_BROWSER': 'firefox'})
     def test_customize_firefox_preferences(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -81,6 +81,21 @@ class TestBrowser(TestCase):
         browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')  # pylint: disable=protected-access
         assert 'firefox_binary' not in browser_kwargs_tuple[2]
 
+    @patch.dict(os.environ, [('SELENIUM_FIREFOX_LOG', '/foo/file.log')])
+    def test_custom_firefox_log(self):
+        browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')  # pylint: disable=protected-access
+        assert 'firefox_binary' in browser_kwargs_tuple[2]
+
+    @patch.dict(os.environ, [('SELENIUM_FIREFOX_LOG', '')])
+    def test_no_custom_firefox_log(self):
+        browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')  # pylint: disable=protected-access
+        assert 'firefox_binary' not in browser_kwargs_tuple[2]
+
+    @patch.dict(os.environ, [('SELENIUM_FIREFOX_PATH', '/foo/path'), ('SELENIUM_FIREFOX_LOG', '/foo/file.log')])
+    def test_custom_firefox_path_and_log(self):
+        browser_kwargs_tuple = bok_choy.browser._local_browser_class('firefox')  # pylint: disable=protected-access
+        assert 'firefox_binary' in browser_kwargs_tuple[2]
+
     def test_profile_error(self):
         """
         If there is a WebDriverException when instantiating the driver,


### PR DESCRIPTION
* Add firefox logging
* Firefox default settings improvements in speed and network usage
  * Disable fetching an updated version of firefox
    **Note**: by default this occurs even though we never will  choose to install the new version
  * Disable plugin checking
  * Disable health reporter
  * Disable all data upload (Telemetry and FHR)
  * Disable crash reporter

@edx/testeng 