### PR TITLE
Support selenium 3.x and newer Firefox versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,13 @@ branches:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
+- sleep 3 # give xvfb some time to start
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz
+- mkdir geckodriver
+- tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver
+- export PATH=$PATH:$PWD/geckodriver
 addons:
-  firefox: '42.0'
+  firefox: '52.0.1'
 install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Running Tests
 
 To run the test suite for bok-choy itself:
 
-* Install Firefox; as of this writing, the current `version 47.0.1 <https://ftp.mozilla.org/pub/firefox/releases/47.0.1/>`_
-  works with the latest selenium Python package (2.53.6)
+* Install Firefox; as of this writing, the current `version 52.0.1 <https://ftp.mozilla.org/pub/firefox/releases/52.0.1/>`_
+  works with the latest selenium Python package (3.3.1)
 * Install `phantomjs <http://phantomjs.org/download.html>`_
 * Create a virtualenv which uses Python 2.7 (or Python 3.5)
 * With that virtualenv activated, run ``pip install -r requirements/tox.txt`` to

--- a/bok_choy/web_app_test.py
+++ b/bok_choy/web_app_test.py
@@ -9,6 +9,7 @@ from unittest import SkipTest
 from uuid import uuid4
 
 from needle.cases import NeedleTestCase, import_from_string
+from needle.driver import NeedlePhantomJS
 import six
 
 from .browser import browser, save_screenshot, save_driver_logs, save_source
@@ -73,6 +74,16 @@ class WebAppTest(NeedleTestCase):
         """
         return self.browser
 
+    def quit_browser(self):
+        """
+        Terminate the web browser which was launched to run the tests.
+        """
+        if isinstance(self.browser, NeedlePhantomJS):
+            # Workaround for https://github.com/SeleniumHQ/selenium/issues/767
+            self.browser.service.send_remote_shutdown_command()
+            self.browser.service._cookie_temp_file = None  # pylint:disable=protected-access
+        self.browser.quit()
+
     def set_viewport_size(self, width, height):
         """
         Override NeedleTestCases's set_viewport_size class method because we need it to operate
@@ -116,7 +127,7 @@ class WebAppTest(NeedleTestCase):
         # Cleanups are executed in LIFO order.
         # This ensures that the screenshot is taken and the driver logs are saved
         # BEFORE the browser quits.
-        self.addCleanup(self.browser.quit)
+        self.addCleanup(self.quit_browser)
         self.addCleanup(self._save_artifacts)
 
     @property

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,11 +3,7 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-
-# Note that to get setup.py to work correctly with needle we have
-# version constraints specified in setup.py as well. We will need
-# to change both to upgrade to selenium 3 or above.
-selenium==2.53.6
+selenium==3.3.1
 
 # Then the direct dependencies
 
@@ -15,7 +11,7 @@ selenium==2.53.6
 lazy==1.2
 
 # For test assertions involving screenshots and visual diffs
-needle==0.4.1
+needle==0.5.0
 
 # For Python 2 & 3 compatibility
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = 'UI-level acceptance test framework'
 REQUIREMENTS = (
     'lazy',
     'needle',
-    'selenium>=2,<3',
+    'selenium>=2,<4',
     'six',
 )
 


### PR DESCRIPTION
Made a few changes to support newer selenium and Firefox versions without removing support for older ones:

* Upgrade needle, which has recently had a number of fixes committed for this.  A new version is expected in the next few days, but this git commit from master lets us move forward with testing in the meantime.  (We can wait until the official needle release before cutting the next bok-choy release.)
* Relax the upper version constraint on selenium in setup.py.
* Work around a PhantomJS shutdown bug which hasn't yet been fixed in the selenium package.
* Update the Travis configuration to use Firefox 52.0.1 and geckodriver.
* Add some time for xvfb to finish starting up in Travis runs (the [Travis documentation](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI) recommends this, and needle's test suite needed it).