### PR TITLE
Catch WebDriverExceptions while waiting for PageObject conditions

### DIFF
--- a/bok_choy/page_object.py
+++ b/bok_choy/page_object.py
@@ -24,6 +24,8 @@ from .promise import Promise, EmptyPromise, BrokenPromise
 from .a11y import AxeCoreAudit, AxsAudit
 
 
+LOGGER = logging.getLogger(__name__)
+
 # String that can be used to test for XSS vulnerabilities.
 # Taken from https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#XSS_Locator.
 XSS_INJECTION = "'';!--\"<XSS>=&{()}"
@@ -79,6 +81,7 @@ def no_selenium_errors(func):
         try:
             return_val = func(*args, **kwargs)
         except WebDriverException:
+            LOGGER.warning(u'Exception ignored during retry loop:', exc_info=True)
             return False
         else:
             return return_val

--- a/bok_choy/query.py
+++ b/bok_choy/query.py
@@ -3,6 +3,8 @@ Tools for interacting with the DOM inside a browser.
 """
 from __future__ import absolute_import
 
+import logging
+
 from copy import copy
 from collections import Sequence
 from itertools import islice
@@ -10,6 +12,8 @@ from selenium.common.exceptions import WebDriverException
 import six
 from bok_choy.promise import Promise
 
+
+LOGGER = logging.getLogger(__name__)
 
 # Mapping of query type to Selenium webdriver query method names
 QUERY_TYPES = {
@@ -39,9 +43,10 @@ def no_error(func):
         try:
             return_val = func(*args, **kwargs)
         except WebDriverException:
-            return (False, None)
+            LOGGER.warning(u'Exception ignored during retry loop:', exc_info=True)
+            return False, None
         else:
-            return (True, return_val)
+            return True, return_val
 
     return _inner
 


### PR DESCRIPTION
Catch WebDriverExceptions during `PageObject.wait_for()` and all derived methods, to avoid failing tests due to side effects of expected page refreshes.  This should help resolve problems like [PLAT-1200](https://openedx.atlassian.net/browse/PLAT-1200).

This is about the minimum change required to accomplish this; we could refactor it a little more to group together and rename `no_error` and `no_selenium_error` if you think it's appropriate.  I just think we should at least leave an import of the `no_error` function in its current module and name for backwards compatibility (since there's nothing to indicate it as private).

I've already tested edx-platform with these changes, and only got a few failures which seem unrelated (they're somewhat flaky even with the bok-choy version currently in use).  I'm digging into those further to see if I can fix them completely.