### PR TITLE
Fix RTD build dependencies

### DIFF
--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,6 +9,11 @@ six==1.10.0
 # Jinja2
 MarkupSafe==0.23
 
+# needle (selenium is also used directly)
+nose==1.3.7
+Pillow==3.3.0
+selenium==3.3.1
+
 # readme_renderer, Sphinx
 docutils==0.12
 Pygments==2.1.3
@@ -26,6 +31,10 @@ snowballstemmer==1.2.1
 edx-sphinx-theme==1.0.2
 
 # Then the direct dependencies
+
+# bok-choy package direct dependencies
+lazy==1.2
+needle==0.5.0
 
 # For verifying that the README will display correctly on PyPI
 readme_renderer==0.7.0


### PR DESCRIPTION
Pin bok-choy's dependencies for the documentation build on Read the Docs so as to avoid conflicts due to using stale packages from the pip cache.