### PR TITLE
Avoid second browser resize when unnecessary

### DIFF
--- a/bok_choy/web_app_test.py
+++ b/bok_choy/web_app_test.py
@@ -101,7 +101,8 @@ class WebAppTest(NeedleTestCase):
         measured = self.driver.execute_script(script)
         delta = width - measured['width']
 
-        self.driver.set_window_size(width + delta, height)
+        if delta > 0:
+            self.driver.set_window_size(width + delta, height)
 
     def setUp(self):
         """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.3.1
+selenium==3.4.3
 
 # Then the direct dependencies
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ MarkupSafe==0.23
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.3.1
+selenium==3.4.3
 
 # readme_renderer, Sphinx
 docutils==0.12


### PR DESCRIPTION
When setting the browser window to a known size for consistent screenshots, bok-choy adapted some code from needle which resizes the browser, determines how much space (if any) is occupied by a scrollbar inside the window, and then resizes it again.  This second resize was done even if there was no scrollbar displayed and hence the second resize was redundant.  In addition to causing a minor performance problem, this was also causing recent versions of Firefox in the Selenium standalone server Docker container to crash for some reason.  I updated the code to only perform the second resize if it would in fact change the browser window's dimensions (which I have yet to see happen, since we only do this at test startup for a blank page).

I also upgraded selenium, because it fixes one test which was failing in Firefox 53+ due to a change in the code for receiving key presses from geckodriver.