### PR TITLE
Disable new Firefox JSON Viewer

### DIFF
--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -314,6 +314,8 @@ def _firefox_profile():
         # Disable crash reporter
         firefox_profile.set_preference('toolkit.crashreporter.enabled', False)
 
+        # Disable the JSON Viewer
+        firefox_profile.set_preference('devtools.jsonview.enabled', False)
     for function in FIREFOX_PROFILE_CUSTOMIZERS:
         function(firefox_profile)
     return firefox_profile


### PR DESCRIPTION
Starting in Firefox 53, raw JSON responses are now displayed in a JSON viewer widget by default.  This is convenient for development, but breaks automated tests which have historically expected JSON to be displayed in the browser as raw text (like many of the tests in edx-platform).  I'm hard pressed to see this viewer being useful in automated tests, so this change disables it by default for new Firefox sessions.