### PR TITLE
update selenium and FF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sleep 3 # give xvfb some time to start
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
 - mkdir geckodriver
-- tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver
+- tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
 - export PATH=$PATH:$PWD/geckodriver
 addons:
-  firefox: '52.0.1'
+  firefox: '57.0.4'
 install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sleep 3 # give xvfb some time to start
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz
 - mkdir geckodriver
-- tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
+- tar -xzf geckodriver-v0.20.0-linux64.tar.gz -C geckodriver
 - export PATH=$PATH:$PWD/geckodriver
 addons:
-  firefox: '57.0.4'
+  firefox: '59.0.1'
 install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -138,24 +138,6 @@ def save_driver_logs(driver, prefix):
         None
     """
     pass
-    # log_types = ['browser', 'driver', 'client', 'server']
-    # for log_type in log_types:
-        # try:
-            # log = driver.get_log(log_type)
-            # file_name = os.path.join(
-                # os.environ.get('SELENIUM_DRIVER_LOG_DIR'), '{}_{}.log'.format(
-                    # prefix, log_type)
-            # )
-            # with open(file_name, 'w') as output_file:
-                # for line in log:
-                    # output_file.write("{}{}".format(dumps(line), '\n'))
-        # except:  # pylint: disable=bare-except
-            # msg = (
-                # "Could not save browser log of type '{log_type}'. "
-                # "It may be that the browser does not support it."
-            # ).format(log_type=log_type)
-
-            # LOGGER.warning(msg, exc_info=True)
 
 
 def browser(tags=None, proxy=None):

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -137,24 +137,25 @@ def save_driver_logs(driver, prefix):
     Returns:
         None
     """
-    log_types = ['browser', 'driver', 'client', 'server']
-    for log_type in log_types:
-        try:
-            log = driver.get_log(log_type)
-            file_name = os.path.join(
-                os.environ.get('SELENIUM_DRIVER_LOG_DIR'), '{}_{}.log'.format(
-                    prefix, log_type)
-            )
-            with open(file_name, 'w') as output_file:
-                for line in log:
-                    output_file.write("{}{}".format(dumps(line), '\n'))
-        except:  # pylint: disable=bare-except
-            msg = (
-                "Could not save browser log of type '{log_type}'. "
-                "It may be that the browser does not support it."
-            ).format(log_type=log_type)
+    pass
+    # log_types = ['browser', 'driver', 'client', 'server']
+    # for log_type in log_types:
+        # try:
+            # log = driver.get_log(log_type)
+            # file_name = os.path.join(
+                # os.environ.get('SELENIUM_DRIVER_LOG_DIR'), '{}_{}.log'.format(
+                    # prefix, log_type)
+            # )
+            # with open(file_name, 'w') as output_file:
+                # for line in log:
+                    # output_file.write("{}{}".format(dumps(line), '\n'))
+        # except:  # pylint: disable=bare-except
+            # msg = (
+                # "Could not save browser log of type '{log_type}'. "
+                # "It may be that the browser does not support it."
+            # ).format(log_type=log_type)
 
-            LOGGER.warning(msg, exc_info=True)
+            # LOGGER.warning(msg, exc_info=True)
 
 
 def browser(tags=None, proxy=None):

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -125,19 +125,35 @@ def save_screenshot(driver, name):
 def save_driver_logs(driver, prefix):
     """
     Save the selenium driver logs.
-
     The location of the driver log files can be configured
     by the environment variable `SELENIUM_DRIVER_LOG_DIR`.  If not set,
     this defaults to the current working directory.
-
     Args:
         driver (selenium.webdriver): The Selenium-controlled browser.
         prefix (str): A prefix which will be used in the output file names for the logs.
-
     Returns:
         None
     """
-    pass
+    browser_name = os.environ.get('SELENIUM_BROWSER', 'firefox')
+    if browser_name != "firefox":
+        log_types = ['browser', 'driver', 'client', 'server']
+        for log_type in log_types:
+            try:
+                log = driver.get_log(log_type)
+                file_name = os.path.join(
+                    os.environ.get('SELENIUM_DRIVER_LOG_DIR'), '{}_{}.log'.format(
+                        prefix, log_type)
+                )
+                with open(file_name, 'w') as output_file:
+                    for line in log:
+                        output_file.write("{}{}".format(dumps(line), '\n'))
+            except:  # pylint: disable=bare-except
+                msg = (
+                    "Could not save browser log of type '{log_type}'. "
+                    "It may be that the browser does not support it."
+                ).format(log_type=log_type)
+
+                LOGGER.warning(msg, exc_info=True)
 
 
 def browser(tags=None, proxy=None):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.8.1
+selenium==3.11.0
 
 # Then the direct dependencies
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.4.3
+selenium==3.8.1
 
 # Then the direct dependencies
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ MarkupSafe==0.23
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.8.1
+selenium==3.11.0
 
 # readme_renderer, Sphinx
 docutils==0.12

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ MarkupSafe==0.23
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.4.3
+selenium==3.8.1
 
 # readme_renderer, Sphinx
 docutils==0.12


### PR DESCRIPTION
In order to run bokchoy tests with FireFox 59.0.1, which contains both the reworked quantum engine and meltdown fixes, selenium 3.11.0 is required. This also upgrades the versions of Firefox and geckodriver used in the travis file