### PR TITLE
Support firefox versions that use marionette

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sleep 3 # give xvfb some time to start
-- wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz
+- wget https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz
 - mkdir geckodriver
-- tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver
+- tar -xzf geckodriver-v0.20.0-linux64.tar.gz -C geckodriver
 - export PATH=$PATH:$PWD/geckodriver
 addons:
-  firefox: '52.0.1'
+  firefox: '59.0.1'
 install:
 - pip install -r requirements/tox.txt
 - pip install tox-travis

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Running Tests
 
 To run the test suite for bok-choy itself:
 
-* Install Firefox; as of this writing, the current `version 52.0.1 <https://ftp.mozilla.org/pub/firefox/releases/52.0.1/>`_
-  works with the latest selenium Python package (3.3.1)
+* Install Firefox; as of this writing, the current `version 59.0.1 <https://ftp.mozilla.org/pub/firefox/releases/59.0.1/>`_
+  works with the latest selenium Python package (3.11.0)
 * Install `phantomjs <http://phantomjs.org/download.html>`_
 * Create a virtualenv which uses Python 2.7 (or Python 3.5)
 * With that virtualenv activated, run ``pip install -r requirements/tox.txt`` to

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -137,6 +137,10 @@ def save_driver_logs(driver, prefix):
     Returns:
         None
     """
+    browser_name = os.environ.get('SELENIUM_BROWSER', 'firefox')
+    if browser_name == "firefox":
+        return
+
     log_types = ['browser', 'driver', 'client', 'server']
     for log_type in log_types:
         try:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.4.3
+selenium==3.11.0
 
 # Then the direct dependencies
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,7 +12,7 @@ MarkupSafe==0.23
 # needle (selenium is also used directly)
 nose==1.3.7
 Pillow==3.3.0
-selenium==3.4.3
+selenium==3.11.0
 
 # readme_renderer, Sphinx
 docutils==0.12


### PR DESCRIPTION
- Bump selenium (3.11.0), geckodriver(0.20), and firefox version (59.0.1)
- Disable selenium webdriver logging for firefox (since this is no longer supported with firefox versions that use marionette)
- Get the TestSaveFiles test class running on Travis again

