### PR TITLE
Added acceptInsecureCerts capability

### DIFF
--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -38,6 +38,7 @@ SAUCE_ENV_VARS = REMOTE_ENV_VARS + [
 OPTIONAL_ENV_VARS = [
     'JOB_NAME',
     'BUILD_NUMBER',
+    'SELENIUM_INSECURE_CERTS',
 ]
 
 
@@ -523,6 +524,7 @@ def _capabilities_dict(envs, tags):
     """
     capabilities = {
         'browserName': envs['SELENIUM_BROWSER'],
+        'acceptInsecureCerts': bool(envs.get('SELENIUM_INSECURE_CERTS', False)),
         'video-upload-on-pass': False,
         'sauce-advisor': False,
         'capture-html': True,


### PR DESCRIPTION
This PR has changes which allows us to add `acceptInsecureCerts` capability to selenium web drivers via `SELENIUM_INSECURE_CERTS` environment variable. 

Background: Accessing a secure page with firefox results in this error
```
selenium.common.exceptions.WebDriverException: Message: Reached error page: about:neterror?e=nssFailure2&u=https://journals.app:18606/search&c=UTF-8&f=regular&d=An error occurred during a connection to journals.app:18606.

SSL received a record that exceeded the maximum permissible length.

Error code: <a id="errorCode" title="SSL_ERROR_RX_RECORD_TOO_LONG">SSL_ERROR_RX_RECORD_TOO_LONG</a>
```
@michaelyoungstrom could you please review?