### PR TITLE
TE-2526 Make needle an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
  - '2.7'
  - '3.5'
  - '3.6'
+env:
+ - TOXENV=core
+ - TOXENV=needle
 sudo: false
 branches:
   only:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.9.0 (08/09/18)
+* Make Needle an optional dependency; everything except visual diffs works without it, nose, and pillow
+
 v0.8.1 (08/01/18)
 * Support use of headless Chrome and Firefox by setting the BOKCHOY_HEADLESS environment variable to "true"
 * Only try to save logs which are available for the browser in use

--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
+	pip-compile --upgrade -o requirements/needle.txt requirements/needle.in
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -11,8 +11,17 @@ import socket
 from json import dumps
 from shutil import copyfile
 
-from needle.driver import (NeedleFirefox, NeedleChrome, NeedleIe,
-                           NeedleSafari, NeedlePhantomJS, NeedleOpera)
+try:
+    from needle.driver import (
+        NeedleChrome as Chrome,
+        NeedleFirefox as Firefox,
+        NeedleIe as Ie,
+        NeedleOpera as Opera,
+        NeedlePhantomJS as PhantomJS,
+        NeedleSafari as Safari
+    )
+except ImportError:
+    from selenium.webdriver import Chrome, Firefox, Ie, Opera, PhantomJS, Safari
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options as ChromeOptions
@@ -45,12 +54,12 @@ OPTIONAL_ENV_VARS = [
 
 
 BROWSERS = {
-    'firefox': NeedleFirefox,
-    'chrome': NeedleChrome,
-    'internet explorer': NeedleIe,
-    'safari': NeedleSafari,
-    'phantomjs': NeedlePhantomJS,
-    'opera': NeedleOpera,
+    'chrome': Chrome,
+    'firefox': Firefox,
+    'internet explorer': Ie,
+    'opera': Opera,
+    'phantomjs': PhantomJS,
+    'safari': Safari,
 }
 
 FIREFOX_PROFILE_ENV_VAR = 'FIREFOX_PROFILE_PATH'

--- a/docs/visual_diff.rst
+++ b/docs/visual_diff.rst
@@ -3,7 +3,13 @@ Visual Diff Testing
 
 The bok-choy framework uses `Needle`_ to provide the ability to capture
 portions of a rendered page in the browser and assert that the image captured
-matches that of a baseline.
+matches that of a baseline.  Needle is an optional dependency of bok-choy,
+which you can install via either of the following commands:
+
+.. code-block:: console
+
+    pip install bok-choy[visual_diff]
+    pip install needle
 
 The general methodology for creating a test with a screenshot assertion
 consists of the following steps.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,5 @@
 # Core requirements for using this application
 
 lazy                      # For lazy evaluation of the page object's a11y_audit attribute
-needle                    # For test assertions involving screenshots and visual diffs
 selenium>=2,<4            # Browser automation driver
 six                       # For Python 2 & 3 compatibility

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,8 +5,6 @@
 #    make upgrade
 #
 lazy==1.3
-needle==0.5.0
-nose==1.3.7               # via needle
-pillow==5.2.0             # via needle
-selenium==3.13.0
+selenium==3.14.0
 six==1.11.0
+urllib3==1.23             # via selenium

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,5 +2,5 @@
 # Please do not use this file for packages that are needed for test runs.
 
 -r pip-tools.txt                    # pip-tools and its dependencies, for managing requirements files
--r test.txt                         # Dependencies for running the various test suites
+-r needle.txt                       # Dependencies for running the various test suites
 -r travis.txt                       # Dependencies for tox and related utilities

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,21 +20,18 @@ imagesize==1.0.0          # via sphinx
 jinja2==2.10              # via sphinx
 lazy==1.3
 markupsafe==1.0           # via jinja2
-needle==0.5.0
-nose==1.3.7
 packaging==17.1           # via sphinx
-pillow==5.2.0
 pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
 pyparsing==2.2.0          # via packaging
 pytz==2018.5              # via babel
 readme-renderer==21.0
 requests==2.19.1          # via sphinx
-selenium==3.13.0
+selenium==3.14.0
 six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
 typing==3.6.4             # via sphinx
-urllib3==1.23             # via requests
+urllib3==1.23
 webencodings==0.5.1       # via html5lib

--- a/requirements/needle.in
+++ b/requirements/needle.in
@@ -1,0 +1,5 @@
+# Requirements for test runs with needle installed for visual diff support
+
+-r test.txt                         # Base testing dependencies
+
+needle                              # For test assertions involving screenshots and visual diffs

--- a/requirements/needle.txt
+++ b/requirements/needle.txt
@@ -9,20 +9,15 @@ astroid==1.5.2
 atomicwrites==1.1.5
 attrs==18.1.0
 backports.functools-lru-cache==1.5
-certifi==2018.4.16
-chardet==3.0.4
 click-log==0.1.8
 click==6.7
-codecov==2.0.15
 configparser==3.5.0
 coverage==4.5.1
 edx-lint==0.5.5
 enum34==1.1.6
 execnet==1.5.0
-first==2.0.1
 funcsigs==1.0.2
 futures==3.2.0 ; python_version == "2.7"
-idna==2.7
 isort==4.3.4
 lazy-object-proxy==1.3.1
 lazy==1.3
@@ -30,12 +25,11 @@ mccabe==0.6.1
 mock==2.0.0
 more-itertools==4.3.0
 needle==0.5.0
-nose==1.3.7
+nose==1.3.7               # via needle
 packaging==17.1
 pathlib2==2.3.2
 pbr==4.2.0
-pillow==5.2.0
-pip-tools==2.0.2
+pillow==5.2.0             # via needle
 pluggy==0.7.1
 py==1.5.4
 pycodestyle==2.4.0
@@ -48,14 +42,9 @@ pytest-cov==2.5.1
 pytest-forked==0.2
 pytest-xdist==1.22.5
 pytest==3.7.1
-requests==2.19.1
 scandir==1.9.0
 selenium==3.14.0
 singledispatch==3.4.0.3
 six==1.11.0
-tox-battery==0.5.1
-tox-travis==0.10
-tox==3.2.1
 urllib3==1.23
-virtualenv==16.0.0
 wrapt==1.10.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,12 +24,9 @@ lazy==1.3
 mccabe==0.6.1             # via pylint
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
-needle==0.5.0
-nose==1.3.7
 packaging==17.1
 pathlib2==2.3.2           # via pytest
 pbr==4.2.0                # via mock
-pillow==5.2.0
 pluggy==0.7.1             # via pytest
 py==1.5.4                 # via pytest
 pycodestyle==2.4.0
@@ -41,9 +38,10 @@ pyparsing==2.2.0          # via packaging
 pytest-cov==2.5.1
 pytest-forked==0.2        # via pytest-xdist
 pytest-xdist==1.22.5
-pytest==3.7.0             # via pytest-cov, pytest-forked, pytest-xdist
-scandir==1.7              # via pathlib2
-selenium==3.13.0
+pytest==3.7.1             # via pytest-cov, pytest-forked, pytest-xdist
+scandir==1.9.0            # via pathlib2
+selenium==3.14.0
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.11.0
+urllib3==1.23
 wrapt==1.10.11            # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -9,14 +9,12 @@ chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.1           # via codecov
 idna==2.7                 # via requests
-packaging==17.1           # via tox
 pluggy==0.7.1             # via tox
 py==1.5.4                 # via tox
-pyparsing==2.2.0          # via packaging
 requests==2.19.1          # via codecov
-six==1.11.0               # via packaging, tox
+six==1.11.0               # via tox
 tox-battery==0.5.1
 tox-travis==0.10
-tox==3.1.2
+tox==3.2.1
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import sys
 from setuptools import setup
 
-VERSION = '0.8.1'
+VERSION = '0.9.0'
 DESCRIPTION = 'UI-level acceptance test framework'
 
 
@@ -74,4 +74,7 @@ setup(
     packages=['bok_choy', 'bok_choy/a11y'],
     package_data={'bok_choy': ['vendor/google/*.*', 'vendor/axe-core/*.*']},
     install_requires=load_requirements('requirements/base.in'),
+    extras_require={
+        'visual_diff': ['needle']
+    }
 )

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -228,12 +228,14 @@ class NextPage(SitePage):
         page.visit()
 
 
+@js_defined('$')
 class FocusedPage(SitePage):
     """
     Page that has a link to a focusable element.
     """
     name = "focused"
 
+    @wait_for_js
     def focus_on_main_content(self):
         """
         Give focus to the element with the ``main-content`` ID.

--- a/tests/test_webapptest.py
+++ b/tests/test_webapptest.py
@@ -1,15 +1,19 @@
 """
 Tests for the WebAppTest class.
 """
+# pylint: disable=attribute-defined-outside-init
 from __future__ import absolute_import
 
 import os
 from unittest import expectedFailure
 
+import pytest
 from bok_choy.web_app_test import WebAppTest
 from .pages import ImagePage
 
 
+@pytest.mark.skipif(not hasattr(WebAppTest, 'engine_class'),
+                    reason='Visual diff assertions only work when needle is installed')
 class ScreenshotAssertTest(WebAppTest):
     """
     Test the integration with needle and its screenshot assertion capability.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # pylint 1.7.1 doesn't support Python 3.7, astroid 1.5.2 doesn't support pypy3
-envlist = py{27,35,36,py}
+envlist = py{27,35,36,py}-{core,needle}
 
 [pytest]
 addopts = --cov bok_choy --cov-report term-missing
@@ -9,7 +9,8 @@ usefixtures = test_server
 
 [testenv]
 deps =
-    -r{toxinidir}/requirements/test.txt
+    core: -r {toxinidir}/requirements/test.txt
+    needle: -r {toxinidir}/requirements/needle.txt
 passenv =
     DISPLAY
     BOKCHOY_HEADLESS


### PR DESCRIPTION
Since we only need `needle` for visual diff assertions (which many repositories using bok-choy don't even utilize), make it an optional dependency.  This has the added bonus of making `nose` and `pillow` optional as well.  Run tests in Travis both with and without these dependencies, to make sure both cases continue working.

The optional dependencies can be installed directly or by installing `bok-choy[visual_diff]`.