### PR TITLE
bump version 0.9.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.9.1 (11/13/18)
+v0.9.2 (11/20/18) (0.9.1 skipped due to PyPI deployment issue)
 * Support passing additional desired capabilities to remote WebDriver instances.
 
 v0.9.0 (08/09/18)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,9 +42,9 @@ author = edx_theme.AUTHOR
 # built documents.
 #
 # The short X.Y version.
-version = '0.9.1'
+version = '0.9.2'
 # The full version, including alpha/beta/rc tags.
-release = '0.9.1'
+release = '0.9.2'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import sys
 from setuptools import setup
 
-VERSION = '0.9.1'
+VERSION = '0.9.2'
 DESCRIPTION = 'UI-level acceptance test framework'
 
 


### PR DESCRIPTION
Rebumping the version to 0.9.2 because the deployment to PyPI failed on the previous version