### PR TITLE
Bump bok-choy version to 1.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v1.0.0 (04/17/19)
+* Bump axe-core dependency from 1.1 to 3.2.2
+
 v0.9.3 (02/14/19)
 * PageLoadError and WrongPageError now inherit WebDriverException so
   they can trigger retries instead of immediately failing tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,9 +42,9 @@ author = edx_theme.AUTHOR
 # built documents.
 #
 # The short X.Y version.
-version = '0.9.2'
+version = '1.0.0'
 # The full version, including alpha/beta/rc tags.
-release = '0.9.2'
+release = '1.0.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import sys
 from setuptools import setup
 
-VERSION = '0.9.3'
+VERSION = '1.0.0'
 DESCRIPTION = 'UI-level acceptance test framework'
 
 


### PR DESCRIPTION
Bump bok-choy version.

**Potential breaking change:**
Leaping axe-core from 1.1 to 3.2.2 for up to date a11y tests.