### PR TITLE
BOM-1001 Fix artifact saving under Python 3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v1.0.1 (10/25/19)
+* Fix saving of test failure artifacts under Python 3
+* Make the saving of page source more robust to missing directories, log problems doing it
+
 v1.0.0 (04/17/19)
 * Bump axe-core dependency from 1.1 to 3.2.2
 

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -97,12 +97,12 @@ def save_source(driver, name):
     if not saved_source_dir:
         LOGGER.warning('The SAVED_SOURCE_DIR environment variable was not set; not saving page source')
         return
-    elif not os.path.exists(saved_source_dir):
-        os.makedirs(saved_source_dir)
     file_name = os.path.join(saved_source_dir,
                              '{name}.html'.format(name=name))
 
     try:
+        if not os.path.exists(saved_source_dir):
+            os.makedirs(saved_source_dir)
         with open(file_name, 'wb') as output_file:
             output_file.write(source.encode('utf-8'))
     except Exception:  # pylint: disable=broad-except

--- a/bok_choy/browser.py
+++ b/bok_choy/browser.py
@@ -93,7 +93,13 @@ def save_source(driver, name):
         None
     """
     source = driver.page_source
-    file_name = os.path.join(os.environ.get('SAVED_SOURCE_DIR'),
+    saved_source_dir = os.environ.get('SAVED_SOURCE_DIR')
+    if not saved_source_dir:
+        LOGGER.warning('The SAVED_SOURCE_DIR environment variable was not set; not saving page source')
+        return
+    elif not os.path.exists(saved_source_dir):
+        os.makedirs(saved_source_dir)
+    file_name = os.path.join(saved_source_dir,
                              '{name}.html'.format(name=name))
 
     try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,9 +42,9 @@ author = edx_theme.AUTHOR
 # built documents.
 #
 # The short X.Y version.
-version = '1.0.0'
+version = '1.0.1'
 # The full version, including alpha/beta/rc tags.
-release = '1.0.0'
+release = '1.0.1'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import sys
 from setuptools import setup
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 DESCRIPTION = 'UI-level acceptance test framework'
 
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -319,7 +319,19 @@ class TestSaveFiles(object):
         # Check that the file is not empty
         assert os.stat(expected_file).st_size > 100
 
-    def test_save_source_missing_directory(self, caplog):
+    def test_save_source_missing_directory(self):
+        shutil.rmtree(self.tempdir_path)
+        os.environ['SAVED_SOURCE_DIR'] = self.tempdir_path
+        ButtonPage(self.browser).visit()
+        bok_choy.browser.save_source(self.browser, 'button_page')
+
+        expected_file = os.path.join(self.tempdir_path, 'button_page.html')
+        assert os.path.isfile(expected_file)
+
+        # Check that the file is not empty
+        assert os.stat(expected_file).st_size > 100
+
+    def test_save_source_no_permission(self, caplog):
         os.environ['SAVED_SOURCE_DIR'] = '/does_not_exist'
         ButtonPage(self.browser).visit()
         bok_choy.browser.save_source(self.browser, 'button_page')

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv =
     MOZ_HEADLESS
     SELENIUM_BROWSER
 setenv =
+    SAVED_SOURCE_DIR={toxinidir}/logs
     SCREENSHOT_DIR={toxinidir}/logs
     SELENIUM_DRIVER_LOG_DIR={toxinidir}/logs
 whitelist_externals =


### PR DESCRIPTION
The code that was used to save debugging artifacts (screenshot, page source, and selenium driver logs) silently stopped working under Python 3.  I added logic to get this working correctly under both Python versions.  Also, the saving of the page source would silently fail if the environment variable for the output directory wasn't set or the directory didn't exist yet; I made this a little more robust by matching what we already do for the screenshot directory.