### PR TITLE
pin importlib-metadata to 1.7.0 for python35

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ urllib3<1.25
 
 # pip-compile fails to find dependencies in 1.8.5 https://github.com/jazzband/pip-tools/issues/810
 sphinx<1.8.5
+
+# make upgrade fails due to conflicts for version>1.7.0 on python3.5
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,7 @@ edx-lint==1.5.2           # via -r requirements/needle.txt
 execnet==1.7.1            # via -r requirements/needle.txt, pytest-xdist
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/needle.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/needle.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/needle.txt, pytest
 isort==4.3.21             # via -r requirements/needle.txt, pylint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
-bleach==3.2.0             # via readme-renderer
+bleach==3.2.1             # via readme-renderer
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 docutils==0.16            # via readme-renderer, sphinx

--- a/requirements/needle.txt
+++ b/requirements/needle.txt
@@ -12,7 +12,7 @@ click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
 edx-lint==1.5.2           # via -r requirements/test.txt
 execnet==1.7.1            # via -r requirements/test.txt, pytest-xdist
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ click==7.1.2              # via click-log, edx-lint
 coverage==5.3             # via pytest-cov
 edx-lint==1.5.2           # via -r requirements/test.in
 execnet==1.7.1            # via pytest-xdist
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,7 +12,7 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.