### PR TITLE
unpinned importlib-metadata constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,3 @@ urllib3<1.25
 
 # pip-compile fails to find dependencies in 1.8.5 https://github.com/jazzband/pip-tools/issues/810
 sphinx<1.8.5
-
-# make upgrade fails due to conflicts for version>1.7.0 on python3.5
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,14 +12,14 @@ certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/needle.txt, edx-lint
 click==7.1.2              # via -r requirements/needle.txt, -r requirements/pip-tools.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
+codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/needle.txt, -r requirements/travis.txt, codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.2           # via -r requirements/needle.txt
 execnet==1.7.1            # via -r requirements/needle.txt, pytest-xdist
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/needle.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/needle.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/needle.txt, pytest
 isort==4.3.21             # via -r requirements/needle.txt, pylint
@@ -44,17 +44,17 @@ pyparsing==2.4.7          # via -r requirements/needle.txt, -r requirements/trav
 pytest-cov==2.10.1        # via -r requirements/needle.txt
 pytest-forked==1.3.0      # via -r requirements/needle.txt, pytest-xdist
 pytest-xdist==2.1.0       # via -r requirements/needle.txt
-pytest==6.1.0             # via -r requirements/needle.txt, pytest-cov, pytest-forked, pytest-xdist
+pytest==6.1.1             # via -r requirements/needle.txt, pytest-cov, pytest-forked, pytest-xdist
 requests==2.24.0          # via -r requirements/travis.txt, codecov
 selenium==3.141.0         # via -r requirements/needle.txt, needle
 six==1.15.0               # via -r requirements/needle.txt, -r requirements/pip-tools.txt, -r requirements/travis.txt, astroid, edx-lint, mock, packaging, pathlib2, pip-tools, tox, virtualenv
 toml==0.10.1              # via -r requirements/needle.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox-travis==0.12          # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery, tox-travis
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery, tox-travis
 typed-ast==1.4.1          # via -r requirements/needle.txt, astroid
 urllib3==1.24.3           # via -c requirements/constraints.txt, -r requirements/needle.txt, -r requirements/travis.txt, requests, selenium
-virtualenv==20.0.32       # via -r requirements/travis.txt, tox
+virtualenv==20.0.33       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/needle.txt, astroid
 zipp==1.2.0               # via -r requirements/needle.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,7 +20,7 @@ packaging==20.4           # via bleach, sphinx
 pygments==2.7.1           # via readme-renderer, sphinx
 pyparsing==2.4.7          # via packaging
 pytz==2020.1              # via babel
-readme-renderer==26.0     # via -r requirements/doc.in
+readme-renderer==27.0     # via -r requirements/doc.in
 requests==2.24.0          # via sphinx
 selenium==3.141.0         # via -r requirements/base.txt
 six==1.15.0               # via bleach, edx-sphinx-theme, packaging, readme-renderer, sphinx

--- a/requirements/needle.txt
+++ b/requirements/needle.txt
@@ -12,7 +12,7 @@ click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 coverage==5.3             # via -r requirements/test.txt, pytest-cov
 edx-lint==1.5.2           # via -r requirements/test.txt
 execnet==1.7.1            # via -r requirements/test.txt, pytest-xdist
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
@@ -35,7 +35,7 @@ pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-forked==1.3.0      # via -r requirements/test.txt, pytest-xdist
 pytest-xdist==2.1.0       # via -r requirements/test.txt
-pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-forked, pytest-xdist
+pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-forked, pytest-xdist
 selenium==3.141.0         # via -r requirements/test.txt, needle
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2
 toml==0.10.1              # via -r requirements/test.txt, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ click==7.1.2              # via click-log, edx-lint
 coverage==5.3             # via pytest-cov
 edx-lint==1.5.2           # via -r requirements/test.in
 execnet==1.7.1            # via pytest-xdist
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
@@ -32,7 +32,7 @@ pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-forked==1.3.0      # via pytest-xdist
 pytest-xdist==2.1.0       # via -r requirements/test.in
-pytest==6.1.0             # via pytest-cov, pytest-forked, pytest-xdist
+pytest==6.1.1             # via pytest-cov, pytest-forked, pytest-xdist
 selenium==3.141.0         # via -r requirements/base.txt
 six==1.15.0               # via astroid, edx-lint, mock, packaging, pathlib2
 toml==0.10.1              # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -23,7 +23,7 @@ six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox-travis==0.12          # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery, tox-travis
+tox==3.20.1               # via -r requirements/travis.in, tox-battery, tox-travis
 urllib3==1.24.3           # via -c requirements/constraints.txt, requests
-virtualenv==20.0.32       # via tox
+virtualenv==20.0.33       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.